### PR TITLE
Remove specific API key handling logic

### DIFF
--- a/embed.py
+++ b/embed.py
@@ -5,9 +5,6 @@ import os
 import numpy as np
 import openai
 
-# TODO: Make this work more universally.
-openai.api_key = os.environ['OPEN_AI_KEY_EMBEDDINGSCRATCHWORK']
-
 
 def embed(text):
     """Embed a single piece of text."""


### PR DESCRIPTION
Closes #4, but the repository configuration must also be modified appropriately.

Taken together with changing the name of the secret to `OPENAI_API_KEY`, this will preserve the ability of the codespace to automatically use the API key, while avoiding logic that could break if other users clone the repository and provide their key differently.

Although codespace secrets apply to all codespaces in a repository, they are not exposed to other repositories, even with the same owner. Thus this simplification will not lead to reusing the same OpenAI API key across separate projects: different GitHub repositories' `OPENAI_API_KEY` secrets are completely separate.

Note that this pull request, if merged without also replacing the secret in the GitHub repository, would break authentication (though it would not introduce a security risk).