### PR TITLE
Add Spanish spell-checking dictionary and related improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
                 "ms-python.python",
                 "MS-vsliveshare.vsliveshare",
                 "stkb.rewrap",
-                "streetsidesoftware.code-spell-checker"
+                "streetsidesoftware.code-spell-checker",
+                "streetsidesoftware.code-spell-checker-spanish"
             ],
             "settings": {
                 "gitlens.showWelcomeOnInstall": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,20 @@
 {
-    "files.trimTrailingWhitespace": true,
+    "cSpell.words": [
+        "bierner",
+        "conda",
+        "devcontainer",
+        "devcontainers",
+        "dtype",
+        "eamodio",
+        "ipykernel",
+        "mhutchie",
+        "numpy",
+        "openai",
+        "scratchwork",
+        "stkb",
+        "Vassallo"
+    ],
     "files.insertFinalNewline": true,
-    "files.trimFinalNewlines": true
+    "files.trimFinalNewlines": true,
+    "files.trimTrailingWhitespace": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,9 @@
         "stkb",
         "Vassallo"
     ],
+    "cSpell.ignoreWords": [
+        "spanish",
+    ],
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "files.trimTrailingWhitespace": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "cSpell.language": "en,es",
     "cSpell.words": [
         "bierner",
         "conda",

--- a/embed.py
+++ b/embed.py
@@ -1,4 +1,4 @@
-"""Embed function for OpenAI API experimenation."""
+"""Embed function for OpenAI API experimentation."""
 
 import os
 


### PR DESCRIPTION
This makes three changes:

- A definite misspelling is fixed. (There was only one.)
- Package names and other "words" that we regard as correctly spelled but that are not Spanish are added in a workspace dictionary. Currently this dictionary is just supplied in `settings.json`, though in the future a separate file could be used if desired.
- The Spanish spell-checking dictionary is added with the appropriate extension included in `devcontainer.json`, and `settings.json` is modified so the spell-checker regards both English and Spanish words to be correctly spelled.

The small handful of remaining words flagged by the spell-checker are variable names that might be changed or factored away in the near future, and since it is not clear that we want to regard them as correct spellings, I didn't add them.