### PR TITLE
Customize dev container git prompt and diff colors

### DIFF
--- a/.devcontainer/git_prompt_activate.bash
+++ b/.devcontainer/git_prompt_activate.bash
@@ -1,0 +1,34 @@
+# This file, when sourced in ~/.bashrc, puts formatted __git_ps1 in $PS1.
+# Based on: https://github.com/EliahKagan/git_prompt_activate
+
+# shellcheck shell=bash
+# shellcheck disable=SC1091  # Not checking /usr/lib/git-core/git-sh-prompt.
+# shellcheck disable=SC2016  # PS1 will contain $ syntax for later expansion.
+# shellcheck disable=SC2034  # GIT_PS1_ vars will be assigned for later use.
+
+if test "$(git config devcontainers-theme.hide-status)" = 1 ||
+   test "$(git config codespaces-theme.hide-status)" = 1
+then
+    . /usr/lib/git-core/git-sh-prompt
+
+    git_prompt_part='$(__git_ps1 "(%s)")'
+
+    case "$TERM" in
+    xterm-color|*-256color) # See color_prompt in .bashrc.
+        git_prompt_part='\[\033[36m\]'"$git_prompt_part"'\[\033[0m\]' ;;
+    esac
+
+    case "$PS1" in
+    *'\$ ')
+        PS1="${PS1/%\\$ /$git_prompt_part\\$ }" ;;
+    *)
+        PS1="${PS1/%$ /$git_prompt_part\\$ }" ;;
+    esac
+
+    unset git_prompt_part
+
+    GIT_PS1_SHOWDIRTYSTATE=1
+    GIT_PS1_SHOWSTASHSTATE=1
+    GIT_PS1_SHOWUNTRACKEDFILES=1
+    GIT_PS1_SHOWUPSTREAM=1
+fi

--- a/.devcontainer/onCreate
+++ b/.devcontainer/onCreate
@@ -2,6 +2,13 @@
 
 set -e
 
+# Customize git configuration for shell prompt and terminal colors.
+ln -s -- "$(realpath .devcontainer/git_prompt_activate.bash)" \
+    ~/.git_prompt_activate.bash
+printf '\n%s\n' '. ~/.git_prompt_activate.bash' >>~/.bashrc
+git config --global color.diff.new blue
+git config --global devcontainers-theme.hide-status 1
+
 # TODO: Do this in a different directory.
 wget https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh
 chmod +x Mambaforge-Linux-x86_64.sh


### PR DESCRIPTION
This addresses a few aspects of the dev container's user experience, though we might revisit them and do something even better in the future. The problems this addresses are:

1. The default bash prompt for dev containers doesn't show new and changed files. It can be made to show unstaged changes by setting `devcontainers-theme.show-dirty` to `1` in the git configuration, but this still does not show changes that have been staged but not committed.

2. The default bash prompt for dev containers doesn't show when we are behind and/or ahead of our remote.

3. The green color used in diffs is hard to distinguish from surrounding text in some light terminal themes, including the default light them used in a codespace.

(1) and (2) are improved by using a slightly customized classic (`__git_ps1`-based) git prompt. In the future, if we want, we could get the advantage of both kinds of prompts by doing more detailed customizations of one of them to incorporate what we consider good about the other.

(3) is improved by changing that green color to blue, which is easy to distinguish from surrounding text in both light and dark themes.