### PR TITLE
Download and run Mambaforge installer in /tmp

### DIFF
--- a/.devcontainer/onCreate
+++ b/.devcontainer/onCreate
@@ -2,12 +2,15 @@
 
 set -e
 
-# TODO: Do this in a different directory.
+# Set up Mambaforge, which provides conda and mamba.
+cd /tmp
 wget https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh
 chmod +x Mambaforge-Linux-x86_64.sh
 ./Mambaforge-Linux-x86_64.sh -b
 rm Mambaforge-Linux-x86_64.sh
 ~/mambaforge/condabin/mamba init --all
 ~/mambaforge/condabin/mamba update --all --yes
+cd -
 
+# Set up project environment for conda/mamba.
 ~/mambaforge/condabin/mamba env create


### PR DESCRIPTION
Since this makes the script slightly longer and more complex, I've also taken this opportunity to add a comment atop each stanza saying what it achieves, so that the complexity will not impede clarity.

Although it's possible for `/tmp` to be on storage optimized for short-term use, the real reason to prefer downloading and running the Mambaforge installer in `/tmp` is for when the dev container is used *locally*, in a specific way: with the workspace on the host instead of in the container.

This is a less common way to use the dev container locally, compared to cloning the repository in the dev container (in which case the workspace is stored on a volume associated with the container). In this situation, there are a few advantages of ensuring that the workspace directory is not used to hold the Mambaforge installer:

- Accessing files on the host from the dev container may be slower. This is rarely a problem on GNU/Linux hosts, but it is always a problem on Windows and macOS hosts (which is why the usual approach of cloning the repo in the container is better on those systems... but it is not always done).

- If the installation fails, `Mambaforge-Linux-x86_64.sh` could be left over in the workspace directory, which could be annoying or confusing or even, occasionally, lead to it being accidentally committed.

- It is possible, though unlikely, that something about the host filesystem is unsuitable. For example, it might not permit files to be marked executable, or it might not have enough free space.

None of these are really big problems, but the fix is simple.