### PR TITLE
Prepare to add requests version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,6 +45,7 @@
         "stkb",
         "tablefmt",
         "tamasfe",
+        "unpatch",
         "Vassallo"
     ],
     "cSpell.ignoreWords": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,6 +38,7 @@
         "pylint",
         "pyver",
         "repr",
+        "safetensors",
         "scratchwork",
         "sh",
         "shellcheck",

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ pip install -e .
 You need an [OpenAI API
 key](https://help.openai.com/en/articles/4936850-where-do-i-find-my-secret-api-key).
 If it is in an environment variable named `OPENAI_API_KEY` then it will be used
-automatically. Otherwise you can assign it to `openai.api_key` in your Python
+automatically. Otherwise you can assign it to `embed.api_key` in your Python
 code.
 
 However you handle your key, make sure not to commit it to any repository. See

--- a/README.md
+++ b/README.md
@@ -40,18 +40,18 @@ multiplication](https://numpy.org/doc/stable/reference/generated/numpy.matmul.ht
 
 ### Major Modules
 
-[`embed.py`](embed.py) contains functions that retrieve embeddings and return
-them as NumPy arrays: rank-1 arrays (vectors) for individual embeddings, or
-rank-2 arrays (matrices) for batches of embeddings.
+[`embed`](embed/__init__.py) contains functions that retrieve embeddings and
+return them as NumPy arrays: rank-1 arrays (vectors) for individual embeddings,
+or rank-2 arrays (matrices) for batches of embeddings.
 
-[`test_embed.py`](tests/test_embed.py) has automated tests of the functions in
-`embed.py`. This includes testing that some examples’ similarities are within
+[`test_embed`](tests/test_embed.py) has automated tests of the functions in
+`embed`. This includes testing that some examples’ similarities are within
 expected ranges.
 
 ### Notebooks
 
 [`embed.ipynb`](notebooks/embed.ipynb) is the main notebook. It shows some
-usage and experiments, calling functions in `embed.py`.
+usage and experiments, calling functions in the `embed` module.
 
 [`structure.ipynb`](notebooks/structure.ipynb) examines the JSON responses
 returned by the OpenAI embeddings API endpoint.
@@ -164,13 +164,13 @@ Code](https://code.visualstudio.com/docs/python/environments).
 
 You may want to start in the [`embed.ipynb`](notebooks/embed.ipynb) notebook.
 
-Then look in, adapt, and/or use the functions defined in
-[`embed.py`](embed.py).
+Then look in, adapt, and/or use the functions defined in the
+[`embed`](embed/__init__.py) module.
 
 ### Automated tests
 
 There are three good ways to run the automated tests in
-[`test_embed.py`](tests/test_embed.py):
+[`test_embed`](tests/test_embed.py):
 
 - In a terminal, activate the environment, then run `python -m unittest`.
 - In VS Code, activate the environment, then click the [beaker
@@ -188,8 +188,8 @@ workflows](.github/workflows/). Forks inherit them, and they [can be
 enabled](https://github.com/github/docs/issues/15761) in a fork’s [“Actions”
 tab](https://loopkit.github.io/loopdocs/gh-actions/gh-first-time/#first-use-of-actions-tab).
 Some will run without problems. Some others—the automated tests in
-[`test_embed.py`](tests/test_embed.py)—cannot run successfully without an
-OpenAI API key.
+[`test_embed`](tests/test_embed.py)—cannot run successfully without an OpenAI
+API key.
 
 #### Your OpenAI API key in CI checks
 
@@ -234,6 +234,8 @@ value of `true` permits this. A value of `false` prohibits it; multiple test
 jobs still run concurrently to download and install their dependencies, but
 actually running the tests is only done by one job at a time. The default, if
 you don’t set `TESTS_CI_NONBLOCKING`, is `false`.
+
+<!-- FIXME: Change embed.py#L39-L54 link to point into embed/__init__.py. -->
 
 This only affects CI, not [manual test runs](#automated-tests). The goal is to
 make this project’s CI checks work even for users whose OpenAI accounts are

--- a/embed/__init__.py
+++ b/embed/__init__.py
@@ -2,7 +2,12 @@
 
 # TODO: Add 2 more functions using requests.
 
-__all__ = ['embed_one', 'embed_many', 'embed_one_eu', 'embed_many_eu']
+__all__ = [
+    'embed_one',
+    'embed_many',
+    'embed_one_eu',
+    'embed_many_eu',
+]
 
 import operator
 

--- a/embed/__init__.py
+++ b/embed/__init__.py
@@ -13,7 +13,6 @@ __all__ = [
 ]
 
 import operator
-import sys
 
 import backoff
 import numpy as np
@@ -22,11 +21,8 @@ import openai.embeddings_utils
 
 from . import _keys
 
-_self = sys.modules[__name__]
-"""This module, to access from its own code only. (For ``_self.api_key``.)"""
-
-# Give this module an api_key property that updates openai.api_key when set.
-_self.__class__ = _keys.KeyForwardingModule
+# Give this module an api_key property to be accessed from the outside.
+_keys.initialize(__name__)
 
 _backoff = backoff.on_exception(backoff.expo, openai.error.RateLimitError)
 """Backoff decorator for ``openai.Embedding.create``-based functions."""

--- a/embed/__init__.py
+++ b/embed/__init__.py
@@ -2,6 +2,9 @@
 
 # TODO: Add 2 more functions using requests.
 
+# TODO: Add a public submodule with versions of all 6 functions that cache (and
+#       check for) embeddings on disk, possibly using safetensors.
+
 __all__ = [
     'embed_one',
     'embed_many',

--- a/embed/__init__.py
+++ b/embed/__init__.py
@@ -10,13 +10,23 @@ __all__ = [
 ]
 
 import operator
+import sys
 
 import backoff
 import numpy as np
 import openai
 import openai.embeddings_utils
 
+from . import _keys
+
+_self = sys.modules[__name__]
+"""This module, to access from its own code only. (For ``_self.api_key``.)"""
+
+# Give this module an api_key property that updates openai.api_key when set.
+_self.__class__ = _keys.KeyForwardingModule
+
 _backoff = backoff.on_exception(backoff.expo, openai.error.RateLimitError)
+"""Backoff decorator for ``openai.Embedding.create``-based functions."""
 
 
 @_backoff

--- a/embed/_keys.py
+++ b/embed/_keys.py
@@ -8,6 +8,11 @@ about ``openai.api_key``. (Setting ``openai.api_key`` to use ``requests``-based
 functions, which don't use ``openai``, would be especially unintuitive.)
 """
 
+# FIXME: Set embed.api_key eagerly rather than lazily, so its behavior doesn't
+#        needlessly diverge from that of openai.api_key.
+
+__all__ = ['KeyForwardingModule']
+
 import os
 import types
 

--- a/embed/_keys.py
+++ b/embed/_keys.py
@@ -15,10 +15,11 @@ __all__ = ['api_key', 'initialize']
 import os
 import sys
 import types
+from typing import Any
 
 import openai
 
-api_key = None
+api_key: Any = None
 """OpenAI API key. This should only be accessed from ``__init__.py``."""
 
 

--- a/embed/_keys.py
+++ b/embed/_keys.py
@@ -1,0 +1,40 @@
+"""
+API key helpers.
+
+This enables the ``embed`` module to have an ``api_key`` property that, when
+set, sets ``openai.api_key``. This is useful because code that consumes this
+project's ``embed`` module shouldn't have to use ``openai`` directly or know
+about ``openai.api_key``. (Setting ``openai.api_key`` to use ``requests``-based
+functions, which don't use ``openai``, would be especially unintuitive.)
+"""
+
+import os
+import types
+
+import openai
+
+
+class KeyForwardingModule(types.ModuleType):
+    """Module whose ``api_key`` property also sets ``openai.api_key``."""
+
+    @property
+    def api_key(self):
+        """OpenAI API key."""
+        try:
+            return self.__api_key
+        except AttributeError:
+            self.set_api_key_from_environment()
+            return self.__api_key
+
+    @api_key.setter
+    def api_key(self, value):
+        self.__api_key = openai.api_key = value
+
+    def set_api_key_from_environment(self):
+        """
+        Set ``api_key`` from the ``OPENAI_API_KEY`` environment variable.
+
+        That happens automatically when the ``api_key`` property is first read.
+        But in multithreaded scenarios, this should be called ahead of time.
+        """
+        self.api_key = os.getenv('OPENAI_API_KEY')  # Calls the setter.

--- a/embed/_keys.py
+++ b/embed/_keys.py
@@ -6,40 +6,51 @@ set, sets ``openai.api_key``. This is useful because code that consumes this
 project's ``embed`` module shouldn't have to use ``openai`` directly or know
 about ``openai.api_key``. (Setting ``openai.api_key`` to use ``requests``-based
 functions, which don't use ``openai``, would be especially unintuitive.)
+
+Code within the ``embed`` module itself may access ``_keys.api_key``.
 """
 
-# FIXME: Set embed.api_key eagerly rather than lazily, so its behavior doesn't
-#        needlessly diverge from that of openai.api_key.
-
-__all__ = ['KeyForwardingModule']
+__all__ = ['api_key', 'initialize']
 
 import os
+import sys
 import types
 
 import openai
 
+api_key = None
+"""OpenAI API key. This should only be accessed from ``__init__.py``."""
 
-class KeyForwardingModule(types.ModuleType):
-    """Module whose ``api_key`` property also sets ``openai.api_key``."""
+
+def initialize(module_or_name):
+    """
+    Give the module an ``api_key`` property and set it from the environment.
+
+    Setting the property sets ``openai.api_key`` (including this first time).
+    """
+    if isinstance(module_or_name, str):  # Because no match-case before 3.10.
+        module = sys.modules[module_or_name]
+    elif isinstance(module_or_name, types.ModuleType):
+        module = module_or_name
+    else:
+        raise TypeError(f'module_or_name is {type(module_or_name).__name__!r}')
+
+    # Give the module an api_key property that updates openai.api_key when set.
+    module.__class__ = _ModuleWithApiKeyProperty
+
+    # Set the property from the environment.
+    module.api_key = os.getenv('OPENAI_API_KEY')
+
+
+class _ModuleWithApiKeyProperty(types.ModuleType):
+    """A module whose ``api_key`` property also sets ``openai.api_key``."""
 
     @property
     def api_key(self):
         """OpenAI API key."""
-        try:
-            return self.__api_key
-        except AttributeError:
-            self.set_api_key_from_environment()
-            return self.__api_key
+        return api_key
 
     @api_key.setter
     def api_key(self, value):
-        self.__api_key = openai.api_key = value
-
-    def set_api_key_from_environment(self):
-        """
-        Set ``api_key`` from the ``OPENAI_API_KEY`` environment variable.
-
-        That happens automatically when the ``api_key`` property is first read.
-        But in multithreaded scenarios, this should be called ahead of time.
-        """
-        self.api_key = os.getenv('OPENAI_API_KEY')  # Calls the setter.
+        global api_key
+        api_key = openai.api_key = value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 license = "0BSD"
 readme = "README.md"
 packages = [
-    { include = "embed.py" },
+    { include = "embed" },
 ]
 
 [build-system]

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""Tests for the embed module."""
+"""Tests for the embedding functions in the ``embed`` module."""
 
 # pylint: disable=missing-function-docstring
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -14,7 +14,7 @@ class TestApiKey(unittest.TestCase):
     """Tests for ``embed.api_key``."""
 
     def setUp(self):
-        """Pre-patch api_key attributes for purposes of log redaction."""
+        """Save api_key attributes. Also pre-patch them, for log redaction."""
         # This cannot be done straightforwardly with unittest.mock.patch
         # because that expects to be able to delete attributes, and the
         # embed.api_key property (deliberately) has no deleter.
@@ -24,7 +24,7 @@ class TestApiKey(unittest.TestCase):
         embed.api_key = 'sk-fake-redact-inner'
 
     def tearDown(self):
-        """Post-unpatch api_key attributes."""
+        """Unpatch api_key attributes."""
         embed.api_key = self._real_key_embed
         openai.api_Key = self._real_key_openai
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -5,6 +5,7 @@
 import unittest
 
 import openai
+from parameterized import parameterized
 
 import embed
 
@@ -27,9 +28,12 @@ class TestApiKey(unittest.TestCase):
         embed.api_key = self._real_key_embed
         openai.api_Key = self._real_key_openai
 
-    def test_setting_sets_openai_api_key(self):
+    @parameterized.expand([
+        ('str', 'sk-fake-setting-sets'),
+        ('none', None),
+    ])
+    def test_setting_sets_openai_api_key(self, _name, pretend_key):
         """Setting ``embed.api_key`` sets both it and ``openai.api_key``."""
-        pretend_key = 'sk-fake-setting-sets'
         embed.api_key = pretend_key
         with self.subTest('embed.api_key'):
             self.assertEqual(embed.api_key, pretend_key)

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+"""Tests for the ``api_key`` property of the ``embed`` module."""
+
+import unittest
+import unittest.mock
+
+import openai
+
+import embed
+
+
+class TestApiKey(unittest.TestCase):
+    """Tests for ``embed.api_key``."""
+
+    @unittest.mock.patch('openai.api_key', 'sk-fake-redact-outer')
+    @unittest.mock.patch('embed.api_key', 'sk-fake-redact-inner')
+    def test_setting_sets_openai_api_key(self):
+        """Setting ``embed.api_key`` sets both it and ``openai.api_key``."""
+        pretend_key = 'sk-fake-setting-sets'
+        embed.api_key = pretend_key
+        with self.subTest('embed.api_key'):
+            self.assertEqual(embed.api_key, pretend_key)
+        with self.subTest('openai.api_key'):
+            self.assertEqual(openai.api_key, pretend_key)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -3,7 +3,6 @@
 """Tests for the ``api_key`` property of the ``embed`` module."""
 
 import unittest
-import unittest.mock
 
 import openai
 
@@ -13,8 +12,21 @@ import embed
 class TestApiKey(unittest.TestCase):
     """Tests for ``embed.api_key``."""
 
-    @unittest.mock.patch('openai.api_key', 'sk-fake-redact-outer')
-    @unittest.mock.patch('embed.api_key', 'sk-fake-redact-inner')
+    def setUp(self):
+        """Pre-patch api_key attributes for purposes of log redaction."""
+        # This cannot be done straightforwardly with unittest.mock.patch
+        # because that expects to be able to delete attributes, and the
+        # embed.api_key property (deliberately) has no deleter.
+        self._real_key_openai = openai.api_key
+        self._real_key_embed = embed.api_key
+        openai.api_key = 'sk-fake-redact-outer'
+        embed.api_key = 'sk-fake-redact-inner'
+
+    def tearDown(self):
+        """Post-unpatch api_key attributes."""
+        embed.api_key = self._real_key_embed
+        openai.api_Key = self._real_key_openai
+
     def test_setting_sets_openai_api_key(self):
         """Setting ``embed.api_key`` sets both it and ``openai.api_key``."""
         pretend_key = 'sk-fake-setting-sets'


### PR DESCRIPTION
**This is a request to merge commits into the `requests` branch, not `main`.**

This makes `embed` a package. It also gives it an `api_key` property that, when set, automatically sets `openai.api_key`. This way, code using `embed` won't have to deal with the `openai` module directly. The main reason for this change is that our forthcoming Requests versions of the embedding functions won't use the OpenAI Python library at all (to actually get the embeddings), so it would be [strange and unexpected](https://en.wikipedia.org/wiki/Principle_of_least_astonishment) for them to use `openai.api_key` and for code that uses our `embed` module to have to import `openai`.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/requests-prep) for unit test status.