### PR TITLE
Add a couple of our formatting settings for VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,6 +50,7 @@
         "spanish",
         "spwe"
     ],
+    "files.eol": "\n",
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "files.trimTrailingWhitespace": true,
@@ -61,5 +62,6 @@
         "test_*.py"
     ],
     "python.testing.pytestEnabled": false,
-    "python.testing.unittestEnabled": true
+    "python.testing.unittestEnabled": true,
+    "rewrap.wrappingColumn": 79,
 }


### PR DESCRIPTION
The important change is making it so VS Code uses LF line endings, since that's the convention we're using for the project. This is set for Git in `.gitattributes`, but VS Code on some platforms, including the web editor, doesn't automatically respect that.

This also adds the PEP-8 recommended 79-character line length to the rewrap extension's settings, so <kbd>Alt</kbd>+<kbd>Q</kbd> does that without requiring it to be otherwise configured.