### PR TITLE
Don't track Jupyter notebook checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Cached Python bytecode
 __pycache__/
+
+# Jupyter notebook checkpoints
+.ipynb_checkpoints/


### PR DESCRIPTION
If someone turns on checkpointing for Jupyter notebooks, or uses an application like JupyterLab where they are on by default (without turning them off), then checkpoints are made in `.ipynb_checkpoints` directories. Usually people prefer not to track those, and tracking them in this project would almost surely be unintentional. So this has Git ignore such directories.