### PR TITLE
Refactor embed_* implementations

### DIFF
--- a/embed/__init__.py
+++ b/embed/__init__.py
@@ -72,18 +72,16 @@ class _RateLimitError(Exception):
 @backoff.on_exception(backoff.expo, _RateLimitError)
 def _post_request(text_or_texts):
     """Make a POST request to the API endpoint, with backoff."""
-    payload = {
-        'input': text_or_texts,
-        'model': 'text-embedding-ada-002'
-    }
-    headers = {
-        'Authorization': f'Bearer {_keys.api_key}',
-        'Content-Type': 'application/json'
-    }
     response = requests.post(
         url='https://api.openai.com/v1/embeddings',
-        json=payload,
-        headers=headers,
+        json={
+            'input': text_or_texts,
+            'model': 'text-embedding-ada-002'
+        },
+        headers={
+            'Authorization': f'Bearer {_keys.api_key}',
+            'Content-Type': 'application/json'
+        },
     )
     if response.status_code == 429:
         raise _RateLimitError

--- a/embed/__init__.py
+++ b/embed/__init__.py
@@ -26,10 +26,6 @@ from . import _keys
 _keys.initialize(__name__)
 
 
-class _RateLimitError(Exception):
-    """An HTTP 429 Too Many Requests error occurred."""
-
-
 @backoff.on_exception(backoff.expo, openai.error.RateLimitError)
 def _create_embedding(text_or_texts):
     """Use the OpenAI library to get one or more embeddings, with backoff."""
@@ -67,6 +63,10 @@ def embed_many_eu(texts):
         engine='text-embedding-ada-002',
     )
     return np.array(embeddings, dtype=np.float32)
+
+
+class _RateLimitError(Exception):
+    """An HTTP 429 Too Many Requests error occurred."""
 
 
 @backoff.on_exception(backoff.expo, _RateLimitError)

--- a/embed/__init__.py
+++ b/embed/__init__.py
@@ -42,28 +42,27 @@ _backoff_requests = backoff.on_exception(
     backoff.expo,
     _RateLimitError,
 )
-"""Backoff decorator for requests-based functions."""
+"""Backoff decorator for ``requests``-based functions."""
 
 
 @_backoff_openai
 def embed_one(text):
     """Embed a single piece of text."""
-    response = openai.Embedding.create(
+    openai_response = openai.Embedding.create(
         input=text,
         model='text-embedding-ada-002',
     )
-    return np.array(response['data'][0]['embedding'], dtype=np.float32)
+    return np.array(openai_response['data'][0]['embedding'], dtype=np.float32)
 
 
 @_backoff_openai
 def embed_many(texts):
     """Embed multiple pieces of text."""
-    response = openai.Embedding.create(
+    openai_response = openai.Embedding.create(
         input=texts,
         model='text-embedding-ada-002',
     )
-
-    data = sorted(response['data'], key=operator.itemgetter('index'))
+    data = sorted(openai_response['data'], key=operator.itemgetter('index'))
     return np.array([datum['embedding'] for datum in data], dtype=np.float32)
 
 
@@ -87,7 +86,7 @@ def embed_many_eu(texts):
 
 @_backoff_requests
 def embed_one_req(text):
-    """Embed a single piece of text. Use requests."""
+    """Embed a single piece of text. Use ``requests``."""
     payload = {
         'input': text,
         'model': 'text-embedding-ada-002'
@@ -109,7 +108,7 @@ def embed_one_req(text):
 
 @_backoff_requests
 def embed_many_req(texts):
-    """Embed multiple pieces of text. Use requests."""
+    """Embed multiple pieces of text. Use ``requests``."""
     payload = {
         'input': texts,
         'model': 'text-embedding-ada-002'

--- a/embed/__init__.py
+++ b/embed/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     'embed_many_req',
 ]
 
+import http
 import operator
 
 import backoff
@@ -83,7 +84,7 @@ def _post_request(text_or_texts):
             'model': 'text-embedding-ada-002'
         },
     )
-    if response.status_code == 429:
+    if response.status_code == http.HTTPStatus.TOO_MANY_REQUESTS:
         raise _RateLimitError
     response.raise_for_status()
     return response.json()

--- a/embed/__init__.py
+++ b/embed/__init__.py
@@ -41,14 +41,14 @@ def _create_embedding(text_or_texts):
 
 def embed_one(text):
     openai_response = _create_embedding(text)
-    return np.array(openai_response['data'][0]['embedding'], dtype=np.float32)
+    return np.array(openai_response.data[0].embedding, dtype=np.float32)
 
 
 def embed_many(texts):
     """Embed multiple pieces of text."""
     openai_response = _create_embedding(texts)
-    data = sorted(openai_response['data'], key=operator.itemgetter('index'))
-    return np.array([datum['embedding'] for datum in data], dtype=np.float32)
+    data = sorted(openai_response.data, key=operator.itemgetter('index'))
+    return np.array([datum.embedding for datum in data], dtype=np.float32)
 
 
 def embed_one_eu(text):

--- a/embed/__init__.py
+++ b/embed/__init__.py
@@ -74,13 +74,13 @@ def _post_request(text_or_texts):
     """Make a POST request to the API endpoint, with backoff."""
     response = requests.post(
         url='https://api.openai.com/v1/embeddings',
-        json={
-            'input': text_or_texts,
-            'model': 'text-embedding-ada-002'
-        },
         headers={
             'Authorization': f'Bearer {_keys.api_key}',
             'Content-Type': 'application/json'
+        },
+        json={
+            'input': text_or_texts,
+            'model': 'text-embedding-ada-002'
         },
     )
     if response.status_code == 429:


### PR DESCRIPTION
Closes #46

This refactors some of the interesting code in the `embed` module. It affects code in `embed/__init__.py`, not in the helper submodule. This includes factoring out the large amount of code that `embed_one_req` and `embed_many_req` duplicated, **but also other changes**. Observable behavior should be unchanged.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/refactor) for unit test status.