### PR TITLE
Let the test workflow be manually triggered

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   check-for-api-key:


### PR DESCRIPTION
This adds the `workflow_dispatch` event trigger, as well as still running the workflow on the `push` and `pull_request` events.

https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow?tool=webui

I recall you had said you'd like to be able to manually trigger some checks. This adds a "Run workflow" button for the Test workflow (in Actions). Unfortunately, I don't know of a way to *verify* that this PR works before merging it; I believe the change has to be applied to the repository's default branch to have this effect.