### PR TITLE
Correct and simplify the test helper module's docstring

### DIFF
--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,4 +1,4 @@
-"""Helper decorators for testing. This supports test_embed.py."""
+"""Helper functions for testing."""
 
 __all__ = ['configure_logging', 'get_maybe_caching_decorator']
 


### PR DESCRIPTION
Closes #54

`tests._helpers.__all__` currently lists two functions, neither of which is a decorator, and only one of which is at all related to decorators. `__all__` is correct; the docstring is wrong. The docstring's wording was from an earlier design I considered for the `_helpers` module, and I never fixed it.

I've also taken this opportunity to remove the mention of how it is used in `test_embed.py`. That's true, but it will become misleading as soon as any other test module uses the `_helpers` module.