### PR TITLE
Improve style (consistency + pylint)

### DIFF
--- a/embed/__init__.py
+++ b/embed/__init__.py
@@ -12,7 +12,6 @@ __all__ = [
     'embed_many_req',
 ]
 
-
 import datetime
 import http
 import operator
@@ -83,11 +82,11 @@ def _post_request(text_or_texts):
         url='https://api.openai.com/v1/embeddings',
         headers={
             'Authorization': f'Bearer {_keys.api_key}',
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
         },
         json={
             'input': text_or_texts,
-            'model': 'text-embedding-ada-002'
+            'model': 'text-embedding-ada-002',
         },
         timeout=_REQUESTS_TIMEOUT.total_seconds(),
     )

--- a/embed/_keys.py
+++ b/embed/_keys.py
@@ -53,5 +53,9 @@ class _ModuleWithApiKeyProperty(types.ModuleType):
 
     @api_key.setter
     def api_key(self, value):
+        # pylint: disable=global-statement
+        #
+        # We really do want to write this submodule's api_key attribute, and
+        # ways of doing it without global are even worse.
         global api_key
         api_key = openai.api_key = value

--- a/notebooks/embed.ipynb
+++ b/notebooks/embed.ipynb
@@ -64,7 +64,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "embedding = embed.embed_one(\"Your text string goes here\")"
+    "embedding = embed.embed_one('Your text string goes here')"
    ]
   },
   {
@@ -114,8 +114,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cat = embed.embed_one(\"cat\")\n",
-    "gato = embed.embed_one(\"gato\")"
+    "cat = embed.embed_one('cat')\n",
+    "gato = embed.embed_one('gato')"
    ]
   },
   {
@@ -126,7 +126,7 @@
     {
      "data": {
       "text/plain": [
-       "0.84436065"
+       "0.8444619"
       ]
      },
      "execution_count": 7,
@@ -164,10 +164,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "catrun_en = embed.embed_one(\"The cat runs.\")\n",
-    "catrun_es = embed.embed_one(\"El gato corre.\")\n",
-    "dogwalk_en = embed.embed_one(\"The dog walks.\")\n",
-    "dogwalk_es = embed.embed_one(\"El perro camina.\")"
+    "catrun_en = embed.embed_one('The cat runs.')\n",
+    "catrun_es = embed.embed_one('El gato corre.')\n",
+    "dogwalk_en = embed.embed_one('The dog walks.')\n",
+    "dogwalk_es = embed.embed_one('El perro camina.')"
    ]
   },
   {
@@ -218,7 +218,7 @@
     {
      "data": {
       "text/plain": [
-       "0.9263702"
+       "0.9269187"
       ]
      },
      "execution_count": 12,
@@ -238,7 +238,7 @@
     {
      "data": {
       "text/plain": [
-       "0.88560975"
+       "0.88565093"
       ]
      },
      "execution_count": 13,
@@ -258,7 +258,7 @@
     {
      "data": {
       "text/plain": [
-       "0.8964852"
+       "0.8966038"
       ]
      },
      "execution_count": 14,
@@ -278,7 +278,7 @@
     {
      "data": {
       "text/plain": [
-       "0.8422606"
+       "0.8422076"
       ]
      },
      "execution_count": 15,
@@ -298,7 +298,7 @@
     {
      "data": {
       "text/plain": [
-       "0.8305687"
+       "0.83059084"
       ]
      },
      "execution_count": 16,
@@ -356,11 +356,11 @@
    ],
    "source": [
     "many = embed.embed_many([\n",
-    "    \"Your text string goes here\",\n",
-    "    \"The cat runs.\",\n",
-    "    \"El gato corre.\",\n",
-    "    \"The dog walks.\",\n",
-    "    \"El perro camina.\",\n",
+    "    'Your text string goes here',\n",
+    "    'The cat runs.',\n",
+    "    'El gato corre.',\n",
+    "    'The dog walks.',\n",
+    "    'El perro camina.',\n",
     "])\n",
     "many.shape"
    ]
@@ -558,7 +558,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "embedding_eu = embed.embed_one_eu(\"Your text string goes here\")"
+    "embedding_eu = embed.embed_one_eu('Your text string goes here')"
    ]
   },
   {
@@ -608,8 +608,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cat_eu = embed.embed_one_eu(\"cat\")\n",
-    "gato_eu = embed.embed_one_eu(\"gato\")"
+    "cat_eu = embed.embed_one_eu('cat')\n",
+    "gato_eu = embed.embed_one_eu('gato')"
    ]
   },
   {
@@ -620,7 +620,7 @@
     {
      "data": {
       "text/plain": [
-       "0.8445959"
+       "0.8447504"
       ]
      },
      "execution_count": 30,
@@ -640,7 +640,7 @@
     {
      "data": {
       "text/plain": [
-       "0.76435125"
+       "0.76458704"
       ]
      },
      "execution_count": 31,
@@ -658,10 +658,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "catrun_en_eu = embed.embed_one_eu(\"The cat runs.\")\n",
-    "catrun_es_eu = embed.embed_one_eu(\"El gato corre.\")\n",
-    "dogwalk_en_eu = embed.embed_one_eu(\"The dog walks.\")\n",
-    "dogwalk_es_eu = embed.embed_one_eu(\"El perro camina.\")"
+    "catrun_en_eu = embed.embed_one_eu('The cat runs.')\n",
+    "catrun_es_eu = embed.embed_one_eu('El gato corre.')\n",
+    "dogwalk_en_eu = embed.embed_one_eu('The dog walks.')\n",
+    "dogwalk_es_eu = embed.embed_one_eu('El perro camina.')"
    ]
   },
   {
@@ -672,7 +672,7 @@
     {
      "data": {
       "text/plain": [
-       "0.9223838"
+       "0.9224265"
       ]
      },
      "execution_count": 33,
@@ -692,7 +692,7 @@
     {
      "data": {
       "text/plain": [
-       "0.7650094"
+       "0.76505"
       ]
      },
      "execution_count": 34,
@@ -712,7 +712,7 @@
     {
      "data": {
       "text/plain": [
-       "0.92692006"
+       "0.9269187"
       ]
      },
      "execution_count": 35,
@@ -732,7 +732,7 @@
     {
      "data": {
       "text/plain": [
-       "0.88560975"
+       "0.88575596"
       ]
      },
      "execution_count": 36,
@@ -752,7 +752,7 @@
     {
      "data": {
       "text/plain": [
-       "0.89665407"
+       "0.8966038"
       ]
      },
      "execution_count": 37,
@@ -772,7 +772,7 @@
     {
      "data": {
       "text/plain": [
-       "0.8422076"
+       "0.84228486"
       ]
      },
      "execution_count": 38,
@@ -792,7 +792,7 @@
     {
      "data": {
       "text/plain": [
-       "0.8305696"
+       "0.83059084"
       ]
      },
      "execution_count": 39,
@@ -850,11 +850,11 @@
    ],
    "source": [
     "many_eu = embed.embed_many_eu([\n",
-    "    \"Your text string goes here\",\n",
-    "    \"The cat runs.\",\n",
-    "    \"El gato corre.\",\n",
-    "    \"The dog walks.\",\n",
-    "    \"El perro camina.\",\n",
+    "    'Your text string goes here',\n",
+    "    'The cat runs.',\n",
+    "    'El gato corre.',\n",
+    "    'The dog walks.',\n",
+    "    'El perro camina.',\n",
     "])\n",
     "many.shape"
    ]
@@ -867,16 +867,16 @@
     {
      "data": {
       "text/plain": [
-       "array([[-6.9754184e-03, -5.3491648e-03,  1.1907940e-02, ...,\n",
-       "        -1.7028622e-02, -8.8358240e-05, -2.4030920e-02],\n",
-       "       [-9.0430975e-03, -4.0786345e-03, -1.1095160e-02, ...,\n",
-       "        -2.4764959e-02,  5.5921902e-03, -2.4191400e-02],\n",
-       "       [-1.4204165e-02, -2.9433765e-03,  4.0550550e-04, ...,\n",
-       "        -8.1148576e-03,  4.9277819e-03, -6.8172398e-03],\n",
-       "       [ 9.5597431e-03, -6.3604913e-03, -5.9328689e-03, ...,\n",
-       "        -1.2309198e-02, -3.6862658e-04, -1.7130248e-02],\n",
-       "       [ 3.3449344e-03, -8.1113884e-03,  1.7457254e-03, ...,\n",
-       "         9.9317353e-05, -9.5703155e-03, -5.5582649e-03]], dtype=float32)"
+       "array([[-6.92928350e-03, -5.33642201e-03,  1.18758921e-02, ...,\n",
+       "        -1.70174073e-02, -4.54713227e-05, -2.40475051e-02],\n",
+       "       [-9.06457007e-03, -4.09244280e-03, -1.10980421e-02, ...,\n",
+       "        -2.47713905e-02,  5.54583408e-03, -2.42741778e-02],\n",
+       "       [-1.42147215e-02, -2.92078988e-03,  3.90018802e-04, ...,\n",
+       "        -8.08201265e-03,  4.93654609e-03, -6.90483581e-03],\n",
+       "       [ 9.59877204e-03, -6.36116648e-03, -5.89548331e-03, ...,\n",
+       "        -1.23801986e-02, -3.47282301e-04, -1.70813799e-02],\n",
+       "       [ 3.45983449e-03, -7.59354141e-03,  1.42495893e-03, ...,\n",
+       "         4.55097703e-04, -8.73538014e-03, -6.12724526e-03]], dtype=float32)"
       ]
      },
      "execution_count": 42,
@@ -896,7 +896,7 @@
     {
      "data": {
       "text/plain": [
-       "0.7650559"
+       "0.7649304"
       ]
      },
      "execution_count": 43,
@@ -916,7 +916,7 @@
     {
      "data": {
       "text/plain": [
-       "0.9223838"
+       "0.9224265"
       ]
      },
      "execution_count": 44,
@@ -936,11 +936,11 @@
     {
      "data": {
       "text/plain": [
-       "array([[0.99999976, 0.76505584, 0.7345198 , 0.75117296, 0.7228675 ],\n",
-       "       [0.76505584, 1.        , 0.9224138 , 0.8857111 , 0.8422665 ],\n",
-       "       [0.7345198 , 0.9224138 , 1.        , 0.8305976 , 0.89663   ],\n",
-       "       [0.75117296, 0.8857111 , 0.8305976 , 1.0000002 , 0.9269196 ],\n",
-       "       [0.7228675 , 0.8422665 , 0.89663   , 0.9269196 , 1.        ]],\n",
+       "array([[1.0000004 , 0.76493055, 0.73437065, 0.7510821 , 0.7233679 ],\n",
+       "       [0.76493055, 1.0000005 , 0.92238605, 0.8856448 , 0.8423538 ],\n",
+       "       [0.73437065, 0.92238605, 1.0000001 , 0.8305839 , 0.8966306 ],\n",
+       "       [0.7510821 , 0.8856448 , 0.8305839 , 1.0000004 , 0.9264928 ],\n",
+       "       [0.7233679 , 0.8423538 , 0.8966306 , 0.9264928 , 0.99999976]],\n",
        "      dtype=float32)"
       ]
      },
@@ -964,16 +964,16 @@
       "text/html": [
        "<table>\n",
        "<tbody>\n",
-       "<tr><td style=\"text-align: right;\">0.999999762</td><td style=\"text-align: right;\">0.765055835</td><td style=\"text-align: right;\">0.734519780</td><td style=\"text-align: right;\">0.751172960</td><td style=\"text-align: right;\">0.722867489</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">0.765055835</td><td style=\"text-align: right;\">1.000000000</td><td style=\"text-align: right;\">0.922413826</td><td style=\"text-align: right;\">0.885711074</td><td style=\"text-align: right;\">0.842266500</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">0.734519780</td><td style=\"text-align: right;\">0.922413826</td><td style=\"text-align: right;\">1.000000000</td><td style=\"text-align: right;\">0.830597579</td><td style=\"text-align: right;\">0.896629989</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">0.751172960</td><td style=\"text-align: right;\">0.885711074</td><td style=\"text-align: right;\">0.830597579</td><td style=\"text-align: right;\">1.000000238</td><td style=\"text-align: right;\">0.926919580</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">0.722867489</td><td style=\"text-align: right;\">0.842266500</td><td style=\"text-align: right;\">0.896629989</td><td style=\"text-align: right;\">0.926919580</td><td style=\"text-align: right;\">1.000000000</td></tr>\n",
+       "<tr><td style=\"text-align: right;\">1.000000358</td><td style=\"text-align: right;\">0.764930546</td><td style=\"text-align: right;\">0.734370649</td><td style=\"text-align: right;\">0.751082122</td><td style=\"text-align: right;\">0.723367929</td></tr>\n",
+       "<tr><td style=\"text-align: right;\">0.764930546</td><td style=\"text-align: right;\">1.000000477</td><td style=\"text-align: right;\">0.922386050</td><td style=\"text-align: right;\">0.885644794</td><td style=\"text-align: right;\">0.842353821</td></tr>\n",
+       "<tr><td style=\"text-align: right;\">0.734370649</td><td style=\"text-align: right;\">0.922386050</td><td style=\"text-align: right;\">1.000000119</td><td style=\"text-align: right;\">0.830583870</td><td style=\"text-align: right;\">0.896630585</td></tr>\n",
+       "<tr><td style=\"text-align: right;\">0.751082122</td><td style=\"text-align: right;\">0.885644794</td><td style=\"text-align: right;\">0.830583870</td><td style=\"text-align: right;\">1.000000358</td><td style=\"text-align: right;\">0.926492810</td></tr>\n",
+       "<tr><td style=\"text-align: right;\">0.723367929</td><td style=\"text-align: right;\">0.842353821</td><td style=\"text-align: right;\">0.896630585</td><td style=\"text-align: right;\">0.926492810</td><td style=\"text-align: right;\">0.999999762</td></tr>\n",
        "</tbody>\n",
        "</table>"
       ],
       "text/plain": [
-       "'<table>\\n<tbody>\\n<tr><td style=\"text-align: right;\">0.999999762</td><td style=\"text-align: right;\">0.765055835</td><td style=\"text-align: right;\">0.734519780</td><td style=\"text-align: right;\">0.751172960</td><td style=\"text-align: right;\">0.722867489</td></tr>\\n<tr><td style=\"text-align: right;\">0.765055835</td><td style=\"text-align: right;\">1.000000000</td><td style=\"text-align: right;\">0.922413826</td><td style=\"text-align: right;\">0.885711074</td><td style=\"text-align: right;\">0.842266500</td></tr>\\n<tr><td style=\"text-align: right;\">0.734519780</td><td style=\"text-align: right;\">0.922413826</td><td style=\"text-align: right;\">1.000000000</td><td style=\"text-align: right;\">0.830597579</td><td style=\"text-align: right;\">0.896629989</td></tr>\\n<tr><td style=\"text-align: right;\">0.751172960</td><td style=\"text-align: right;\">0.885711074</td><td style=\"text-align: right;\">0.830597579</td><td style=\"text-align: right;\">1.000000238</td><td style=\"text-align: right;\">0.926919580</td></tr>\\n<tr><td style=\"text-align: right;\">0.722867489</td><td style=\"text-align: right;\">0.842266500</td><td style=\"text-align: right;\">0.896629989</td><td style=\"text-align: right;\">0.926919580</td><td style=\"text-align: right;\">1.000000000</td></tr>\\n</tbody>\\n</table>'"
+       "'<table>\\n<tbody>\\n<tr><td style=\"text-align: right;\">1.000000358</td><td style=\"text-align: right;\">0.764930546</td><td style=\"text-align: right;\">0.734370649</td><td style=\"text-align: right;\">0.751082122</td><td style=\"text-align: right;\">0.723367929</td></tr>\\n<tr><td style=\"text-align: right;\">0.764930546</td><td style=\"text-align: right;\">1.000000477</td><td style=\"text-align: right;\">0.922386050</td><td style=\"text-align: right;\">0.885644794</td><td style=\"text-align: right;\">0.842353821</td></tr>\\n<tr><td style=\"text-align: right;\">0.734370649</td><td style=\"text-align: right;\">0.922386050</td><td style=\"text-align: right;\">1.000000119</td><td style=\"text-align: right;\">0.830583870</td><td style=\"text-align: right;\">0.896630585</td></tr>\\n<tr><td style=\"text-align: right;\">0.751082122</td><td style=\"text-align: right;\">0.885644794</td><td style=\"text-align: right;\">0.830583870</td><td style=\"text-align: right;\">1.000000358</td><td style=\"text-align: right;\">0.926492810</td></tr>\\n<tr><td style=\"text-align: right;\">0.723367929</td><td style=\"text-align: right;\">0.842353821</td><td style=\"text-align: right;\">0.896630585</td><td style=\"text-align: right;\">0.926492810</td><td style=\"text-align: right;\">0.999999762</td></tr>\\n</tbody>\\n</table>'"
       ]
      },
      "execution_count": 46,
@@ -1009,7 +1009,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "embedding_req = embed.embed_one_req(\"Your text string goes here\")"
+    "embedding_req = embed.embed_one_req('Your text string goes here')"
    ]
   },
   {
@@ -1020,8 +1020,8 @@
     {
      "data": {
       "text/plain": [
-       "array([-6.9292835e-03, -5.3364220e-03,  1.1875892e-02, ...,\n",
-       "       -1.7017407e-02, -4.5471323e-05, -2.4047505e-02], dtype=float32)"
+       "array([-6.9754184e-03, -5.3491648e-03,  1.1907940e-02, ...,\n",
+       "       -1.7028622e-02, -8.8358240e-05, -2.4030920e-02], dtype=float32)"
       ]
      },
      "execution_count": 48,
@@ -1059,8 +1059,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cat_req = embed.embed_one_req(\"cat\")\n",
-    "gato_req = embed.embed_one_req(\"gato\")"
+    "cat_req = embed.embed_one_req('cat')\n",
+    "gato_req = embed.embed_one_req('gato')"
    ]
   },
   {
@@ -1071,7 +1071,7 @@
     {
      "data": {
       "text/plain": [
-       "0.84464866"
+       "0.8444619"
       ]
      },
      "execution_count": 51,
@@ -1091,7 +1091,7 @@
     {
      "data": {
       "text/plain": [
-       "0.7644648"
+       "0.7642809"
       ]
      },
      "execution_count": 52,
@@ -1109,10 +1109,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "catrun_en_req = embed.embed_one_req(\"The cat runs.\")\n",
-    "catrun_es_req = embed.embed_one_req(\"El gato corre.\")\n",
-    "dogwalk_en_req = embed.embed_one_req(\"The dog walks.\")\n",
-    "dogwalk_es_req = embed.embed_one_req(\"El perro camina.\")"
+    "catrun_en_req = embed.embed_one_req('The cat runs.')\n",
+    "catrun_es_req = embed.embed_one_req('El gato corre.')\n",
+    "dogwalk_en_req = embed.embed_one_req('The dog walks.')\n",
+    "dogwalk_es_req = embed.embed_one_req('El perro camina.')"
    ]
   },
   {
@@ -1123,7 +1123,7 @@
     {
      "data": {
       "text/plain": [
-       "0.92243814"
+       "0.9224139"
       ]
      },
      "execution_count": 54,
@@ -1143,7 +1143,7 @@
     {
      "data": {
       "text/plain": [
-       "0.7649304"
+       "0.7650559"
       ]
      },
      "execution_count": 55,
@@ -1163,7 +1163,7 @@
     {
      "data": {
       "text/plain": [
-       "0.92692006"
+       "0.92638606"
       ]
      },
      "execution_count": 56,
@@ -1183,7 +1183,7 @@
     {
      "data": {
       "text/plain": [
-       "0.88560975"
+       "0.88566977"
       ]
      },
      "execution_count": 57,
@@ -1203,7 +1203,7 @@
     {
      "data": {
       "text/plain": [
-       "0.8966038"
+       "0.89643717"
       ]
      },
      "execution_count": 58,
@@ -1223,7 +1223,7 @@
     {
      "data": {
       "text/plain": [
-       "0.8422076"
+       "0.84225607"
       ]
      },
      "execution_count": 59,
@@ -1243,7 +1243,7 @@
     {
      "data": {
       "text/plain": [
-       "0.8305687"
+       "0.8305751"
       ]
      },
      "execution_count": 60,
@@ -1301,11 +1301,11 @@
    ],
    "source": [
     "many_req = embed.embed_many_req([\n",
-    "    \"Your text string goes here\",\n",
-    "    \"The cat runs.\",\n",
-    "    \"El gato corre.\",\n",
-    "    \"The dog walks.\",\n",
-    "    \"El perro camina.\",\n",
+    "    'Your text string goes here',\n",
+    "    'The cat runs.',\n",
+    "    'El gato corre.',\n",
+    "    'The dog walks.',\n",
+    "    'El perro camina.',\n",
     "])\n",
     "many.shape"
    ]
@@ -1367,7 +1367,7 @@
     {
      "data": {
       "text/plain": [
-       "0.92243814"
+       "0.9224139"
       ]
      },
      "execution_count": 65,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,6 @@ packages = [
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pylint.main]
+disable = ["too-few-public-methods"]

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -35,20 +35,20 @@ class TestEmbedOne(unittest.TestCase):
     func: Any
 
     def test_returns_numpy_array(self):
-        result = self.func("Your text string goes here")
+        result = self.func('Your text string goes here')
         with self.subTest('ndarray'):
             self.assertIsInstance(result, np.ndarray)
         with self.subTest('float32'):
             self.assertIsInstance(result[0], np.float32)
 
     def test_shape_is_model_dimension(self):
-        result = self.func("Your text string goes here")
+        result = self.func('Your text string goes here')
         self.assertEqual(result.shape, (1536,))
 
     @parameterized.expand([
-        ("catrun", "The cat runs.", "El gato corre."),
-        ("dogwalk", "The dog walks.", "El perro camina."),
-        ("lionsleep", "The lion sleeps.", "El león duerme."),
+        ('catrun', 'The cat runs.', 'El gato corre.'),
+        ('dogwalk', 'The dog walks.', 'El perro camina.'),
+        ('lionsleep', 'The lion sleeps.', 'El león duerme.'),
     ])
     def test_en_and_es_sentence_are_very_similar(
             self, _name, text_en, text_es):
@@ -58,8 +58,8 @@ class TestEmbedOne(unittest.TestCase):
         self.assertGreaterEqual(result, 0.9)
 
     def test_different_meanings_are_dissimilar(self):
-        sentence_one = self.func("Your text string goes here")
-        sentence_two = self.func("The cat runs.")
+        sentence_one = self.func('Your text string goes here')
+        sentence_two = self.func('The cat runs.')
         result = np.dot(sentence_one, sentence_two)
         self.assertLess(result, 0.8)
 
@@ -77,11 +77,11 @@ class TestEmbedMany(unittest.TestCase):
 
     def setUp(self):
         self._many = self.func([
-            "Your text string goes here",
-            "The cat runs.",
-            "El gato corre.",
-            "The dog walks.",
-            "El perro camina.",
+            'Your text string goes here',
+            'The cat runs.',
+            'El gato corre.',
+            'The dog walks.',
+            'El perro camina.',
         ])
 
     def test_returns_numpy_array(self):

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -44,7 +44,7 @@ class TestApiKey(unittest.TestCase):
         ('str', 'sk-fake-setting-does-not-set'),
         ('none', None),
     ])
-    def test_setting_on_openai_does_not_set_on_embed(self, name, pretend_key):
+    def test_setting_on_openai_does_not_set_on_embed(self, _name, pretend_key):
         """Setting ``open.api_key`` does not change ``embed.api_key``."""
         openai.api_key = pretend_key
         self.assertNotEqual(embed.api_key, pretend_key)


### PR DESCRIPTION
This addresses some stylistic inconsistencies, fixes a mistake pylint rightly caught, suppresses a warning pylint flagged but is reasonable in context, and suppresses another pylint warning project-wide that I don't think is ever likely to identify anything we should change (in this project).

One of the stylistic inconsistencies this addresses is which, of single or double quotes, is preferred as the default in Python code (when there is no strong reason to prefer one over the other). I picked single quotes, since that's what newer code in the project (including other feature branches) is doing. But you might decide to change it all to double quotes later. I think it's worth having it be consistent, and that consistency is more important than which convention is chosen.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/style) for unit test status.