### PR TITLE
Change _post_request backoff to use on_predicate

### DIFF
--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -41,7 +41,7 @@ _BATCH_SIZE = 8
 
 _is_backoff_message = re.compile(
     r'INFO:backoff:Backing off _post_request\(\.\.\.\) for [0-9.]+s '
-    r'\(embed\._RateLimitError\)',
+    r'\(<Response \[429\]>\)',
 ).fullmatch
 """Check if the string is a log message about backoff with expected details."""
 


### PR DESCRIPTION
This reorganizes helpers in `embed/__init__.py` so the `_post_request` function returns the Response object and is no longer responsible for converting any HTTP errors into exceptions. Instead of `@backoff.expo`, `_post_request` is decorated `@backoff.on_predicate`, with a predicate that checks for a *429 Too Many Requests* status.

Although this is more direct and eliminates our helper exception, the more significant benefit of this change is so that no details of an HTTP 492 error are ever suppressed. So, for example, if we (or anyone) ever specify a maximum number of retries, then the `@backoff.on_predicate` wrapper function will eventually return the Response object in the HTTP 429 error state with rich information.

In contrast, if a maximum number of retries were given to `@backoff.expo` with our `_RateLimitError`, then that exception would propagate out of the wrapper. But that exception *(a)* was just an implementation detail, and more importantly *(b)* didn't have rich error (or other) information from the HTTP response.

I think this new approach is also more elegant, because now all unhandled HTTP errors are (including if a maximum number of retries is later added) handled in a uniform way: when the callers call `response.raise_for_status` on the `Response` object, an `HTTPError` is raised if the request was unsuccessful (any status besides 200).

I used the test introduced in #58 (with the appropriate small modification) to verify that this works. See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/backoff) for other unit test output.