### PR TITLE
Add optional data_dir kwarg to _disk_cache wrapper

### DIFF
--- a/embed/cached.py
+++ b/embed/cached.py
@@ -18,17 +18,14 @@ import numpy as np
 
 import embed
 
-_DATA_DIR = pathlib.Path('data')
-"""Directory to cache embeddings."""
-
 
 def _disk_cache(func):
     """Decorator to add disk caching to an embedding function."""
     @functools.wraps(func)
-    def wrapper(text_or_texts):
+    def wrapper(text_or_texts, *, data_dir='data'):
         serialized = json.dumps(text_or_texts).encode()
         basename = blake3.blake3(serialized).hexdigest()
-        path = _DATA_DIR / f'{basename}.json'
+        path = pathlib.Path(data_dir, f'{basename}.json')
 
         try:
             with open(path, mode='r', encoding='utf-8') as file:


### PR DESCRIPTION
**This is a request to merge commits into the [`cached`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/cached) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

This allows a custom data directory to be specified as an optional keyword-only argument to wrapper functions returned by `_disk_cache`. For example, this now works:

```python
embed.cached.embed_many(['hello', 'goodbye'], data_dir='/path/to/dir')
```

I think we should not wait to add such a feature, because having it will make automated testing much easier, since a test fixture can provide per-test temporary directories (whose names are dynamically generated) to prevent the test and whatever we store in the repository's `data` directory from depending on each other, and to prevent separate tests from interfering with each other.

However, even if you accept this PR, the approach of having a `data_dir` keyword argument (along with other aspects of the caching design and implementation) shouldn't be considered set in stone. My goal is the opposite: I think this feature increases testability, making it easier and faster to change things, including this feature itself.

If, in the future, we *do* decide to keep this design and to keep the `data_dir` argument, then some of the issues detailed in the 74f3392 commit message will eventually have to be considered.