### PR TITLE
Make getenv_bool public and use @skipUnless on TestBackoff

### DIFF
--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,6 +1,6 @@
 """Helper functions for testing."""
 
-__all__ = ['configure_logging', 'get_maybe_caching_decorator']
+__all__ = ['getenv_bool', 'configure_logging', 'get_maybe_caching_decorator']
 
 import atexit
 import collections
@@ -63,7 +63,7 @@ _falsy_config = re.compile(r'(?:false|no|0)?', re.IGNORECASE).fullmatch
 """Check if a configuration string should be considered to mean ``False``."""
 
 
-def _getenv_bool(name):  # NOTE: This can be made public, if that is useful.
+def getenv_bool(name):
     """
     Read boolean configuration from an environment variable.
 
@@ -113,6 +113,6 @@ def get_maybe_caching_decorator():
 
     Otherwise, the returned decorator is just an identity function.
     """
-    if _getenv_bool('TESTS_CACHE_EMBEDDING_CALLS'):
+    if getenv_bool('TESTS_CACHE_EMBEDDING_CALLS'):
         return _cache_by(pickle.dumps, stats=_cache_stats)
     return _identity_function

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -28,6 +28,7 @@ import re
 import threading
 import unittest
 
+from . import _helpers
 import embed
 
 _STACK_SIZE = 32_768
@@ -56,12 +57,10 @@ def _run_batch(batch_index):
         )
 
 
-# NOTE: Manually enable this briefly if needed, but otherwise keep it skipped.
-#
-# TODO: After PR #56, run if the TESTS_RUN_BACKOFF_TEST_I_KNOW_WHAT_I_AM_DOING
-#       environment variable is set to a truthy value (but still NEVER on CI).
-#
-@unittest.skip("No need to regularly slam OpenAI's servers. Also: very slow.")
+@unittest.skipUnless(
+    _helpers.getenv_bool('TESTS_RUN_BACKOFF_TEST_I_KNOW_WHAT_I_AM_DOING'),
+    "No need to regularly slam OpenAI's servers. Also: very slow.",
+)
 class TestBackoff(unittest.TestCase):
     """
     Test backoff in one of the functions using ``requests`` (``test_one_req``).


### PR DESCRIPTION
This makes `_helpers.getenv_bool` public (still private to the tests, since it is a `_` module, but meant for consumption from other test modules) and changes `test_backoff.TestBackoff` to use `@skipUnless` instead of `@skip`. The "unless" condition is determined by using `getenv_bool` to check for a `TESTS_RUN_BACKOFF_TEST_I_KNOW_WHAT_I_AM_DOING` environment variable with a truthy value. That's why this PR makes both those changes: making `getenv_bool` public without anything outside its module using it doesn't really make sense, since it's still private to the tests, and `test_backoff` shouldn't consume `getenv_bool` unless it is public.

This affects a test that doesn't (and shouldn't) run on CI, but I've tested the change on my local machine. See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/tests) for other unit test output.