### PR TITLE
Fix expected path construction on Windows

### DIFF
--- a/tests/test_cached.py
+++ b/tests/test_cached.py
@@ -4,6 +4,7 @@
 
 # pylint: disable=missing-function-docstring
 
+import pathlib
 import tempfile
 import unittest
 
@@ -22,11 +23,12 @@ class TestCached(unittest.TestCase):
 
     def setUp(self):
         """Create a temporary directory."""
-        self._dir = tempfile.TemporaryDirectory()
+        self._temporary_directory = tempfile.TemporaryDirectory()
+        self._dir_path = pathlib.Path(self._temporary_directory.name)
 
     def tearDown(self):
         """Delete the temporary directory."""
-        self._dir.cleanup()
+        self._temporary_directory.cleanup()
 
     # Test saving new files
     def test_saving_new_file_embed_one(self):
@@ -34,10 +36,12 @@ class TestCached(unittest.TestCase):
         basename = (
             'b58e4a60c963f8b3c43d83cc9245020ce71d8311fa2f48cfd36deed6f472a71b'
         )
-        message = f'{prefix} {self._dirname}/{basename}.json'
+        expected_message = f'{prefix} {self._dir_path / basename}.json'
+
         with self.assertLogs() as cm:
-            embed_one('hola', data_dir=self._dirname)
-        self.assertEqual(cm.output, [message])
+            embed_one('hola', data_dir=self._dir_path)
+
+        self.assertEqual(cm.output, [expected_message])
 
     # Test loading existing files
 
@@ -46,10 +50,6 @@ class TestCached(unittest.TestCase):
     # Test log corresponds to what occurred
 
     # Test even when data_dir is not passed
-
-    @property
-    def _dirname(self):
-        return self._dir.name
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**This is a request to merge commits into the [`cached`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/cached) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

The code under test builds paths with the operating system's default path separator (as it should), but the test code contained a literal `/` separator. On Windows, a `\` appears instead, failing the test. This fixes that by using `pathlib.Path` in the test logic. I've done it a little differently from the code under test, though it may be worth exploring ways to further reduce similarity between the test and the code under test.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/cached-next) to confirm that the Windows tests failed in the previous commit but pass on this one.