### PR TITLE
Fix running test modules as scripts

### DIFF
--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -28,7 +28,7 @@ import re
 import threading
 import unittest
 
-from . import _helpers
+from tests import _helpers
 import embed
 
 _STACK_SIZE = 32_768

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -18,7 +18,7 @@ from embed import (
     embed_one_req,
     embed_many_req,
 )
-from . import _helpers
+from tests import _helpers
 
 _helpers.configure_logging()
 _maybe_cache = _helpers.get_maybe_caching_decorator()


### PR DESCRIPTION
Closes #66

The `test_embed` and `test_backoff` modules used relative imports for the `_helper` module, which inadvertently kept them from working when run as scripts. This changes them to be absolute imports.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/tests) for unit test status. We don't have any CI jobs that execute the test modules as scripts, but I've tested this locally on an Ubuntu 22.04 system.