### PR TITLE
Start work to support poetry

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,6 @@
     "image": "mcr.microsoft.com/devcontainers/python:0-3.11-bullseye",
     "features": {
         "ghcr.io/devcontainers/features/sshd:1": {},
-        "ghcr.io/devcontainers-contrib/features/poetry:2": {},
         "ghcr.io/lukewiwa/features/shellcheck:0": {}
     },
     "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
-    "image": "mcr.microsoft.com/devcontainers/base:0-bullseye",
+    "image": "mcr.microsoft.com/devcontainers/python:0-3.11-bullseye",
     "features": {
         "ghcr.io/devcontainers/features/sshd:1": {},
+        "ghcr.io/devcontainers-contrib/features/poetry:2": {},
         "ghcr.io/lukewiwa/features/shellcheck:0": {}
     },
     "customizations": {
@@ -22,7 +23,8 @@
             ],
             "settings": {
                 "gitlens.showWelcomeOnInstall": false,
-                "gitlens.showWhatsNewAfterUpgrades": false
+                "gitlens.showWhatsNewAfterUpgrades": false,
+                "python.terminal.activateEnvironment": false
             }
         }
     },

--- a/.devcontainer/onCreate
+++ b/.devcontainer/onCreate
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e
+set -eu
 
 # Customize git configuration for shell prompt and terminal colors.
 ln -s -- "$(realpath .devcontainer/git_prompt_activate.bash)" \
@@ -16,9 +16,13 @@ chmod +x Mambaforge-Linux-x86_64.sh
 ./Mambaforge-Linux-x86_64.sh -b
 rm Mambaforge-Linux-x86_64.sh
 ~/mambaforge/condabin/mamba init --all
+~/mambaforge/condabin/conda config --set auto_activate_base false
 ~/mambaforge/condabin/mamba update --all --yes
 cd -
 
 # Set up project environment for conda/mamba.
 ~/mambaforge/condabin/mamba env create
 ~/mambaforge/condabin/mamba run --name EmbeddingScratchwork pip install -e .
+
+# Set up project environment for poetry.
+# poetry install  # FIXME: Uncomment once pyproject.toml lists dependencies.

--- a/.devcontainer/onCreate
+++ b/.devcontainer/onCreate
@@ -9,6 +9,10 @@ printf '\n%s\n' '. ~/.git_prompt_activate.bash' >>~/.bashrc
 git config --global color.diff.new blue
 git config --global devcontainers-theme.hide-status 1
 
+# Set up Poetry and its plugins.
+pipx install poetry
+pipx inject poetry poetry-plugin-sort poetry-plugin-up
+
 # Set up Mambaforge, which provides conda and mamba.
 cd /tmp
 wget https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh

--- a/README.md
+++ b/README.md
@@ -75,22 +75,38 @@ generates some test data used in `test_cached_embeddings`.
 
 ### Way 1: Local
 
-#### Obtaining and installing
+Clone the project, then install it with either
+[`poetry`](https://python-poetry.org/) or
+[`conda`](https://en.wikipedia.org/wiki/Conda_(package_manager)).
 
-Clone the repository and create its
-[`conda`](https://en.wikipedia.org/wiki/Conda_(package_manager)) environment:
+#### Cloning the project
+
+Wherever you want the project directory to be created, run:
 
 ```sh
 git clone https://github.com/dmvassallo/EmbeddingScratchwork.git
 cd EmbeddingScratchwork
+```
+
+If you forked the project (and want to use your fork), replace the URL with
+that of your fork.
+
+#### Installing with `poetry`
+
+```sh
+poetry install
+```
+
+#### Installing with `conda`
+
+```sh
 conda env create
 conda activate EmbeddingScratchwork
 pip install -e .
 ```
 
-- If you fork the project, remember to replace the URL with that of your fork.
-- [`mamba`](https://mamba.readthedocs.io/en/latest/installation.html) may be
-  used in place of `conda` if it is installed.
+[`mamba`](https://mamba.readthedocs.io/en/latest/installation.html) may be used
+in place of `conda` if it is installed.
 
 #### Your OpenAI API key
 
@@ -109,6 +125,10 @@ Safety](https://help.openai.com/en/articles/5112595-best-practices-for-api-key-s
 The configuration in [`.devcontainer/`](.devcontainer/) will be used
 automatically when you create a
 [codespace](https://github.com/features/codespaces) on GitHub.
+
+The dev container has both the `poetry`-managed Python virtual environment and
+the `conda` environment set up. So you can [activate and
+use](#activating-the-environment) whichever you like.
 
 #### Creating the codespace
 
@@ -152,7 +172,16 @@ Safety](https://help.openai.com/en/articles/5112595-best-practices-for-api-key-s
 ### 3. Local dev container
 
 Dev containers are often used in codespaces but you can also run them locally
-with VS Code and Docker. [Here are some general
+with VS Code and Docker. The dev container has the same functionality in the
+container as when run in a codespace. So, as in a codespace, the project is set
+up in the container both with `poetry` and `conda` and you can use either kind
+of environment.
+
+Since a local dev container does not run in a codespace, a GitHub Codespaces
+repository secret has no effect on a locally run dev container, and you’ll have
+to manage your API key in some other way.
+
+[Here are some general
 instructions](https://code.visualstudio.com/docs/devcontainers/tutorial) for
 running dev containers on your own machine.
 
@@ -160,16 +189,31 @@ running dev containers on your own machine.
 
 ## Usage
 
-### Activating the conda environment
+### Activating the environment
 
-To activate the conda environment in your shell:
+#### With `poetry`
+
+If you [installed with `poetry`](#installing-with-poetry), run this to start a
+shell with the `poetry`-managed Python virtual environment activated:
+
+```sh
+poetry shell
+```
+
+#### With `conda`
+
+If you [installed with `conda`](#installing-with-conda), run this to activate
+the `conda` environment in your shell:
 
 ```sh
 conda activate EmbeddingScratchwork
 ```
 
-Or activate the environment in an editor/IDE, such as VS Code, by selecting the
-environment (or the `python` interpreter in it) in the editor/IDE’s interface.
+#### With your editor/IDE
+
+Whether your installed with `poetry` or `conda`, you can activate the
+environment in an editor or IDE, such as VS Code, by selecting the environment
+or its Python interpreter in the editor/IDE’s interface.
 
 For specific information about how to do this with VS Code, see [Using Python
 environments in VS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,21 @@
-# Currently, this file exists only to allow "pip install -e ." to succeed when
-# run in the conda environment. In the future we might support poetry, in which
-# case this file will be repaced with a generated file that lists dependencies.
+# FIXME: Previously, this file existed only to allow "pip install -e ." to
+# succeed when run in the conda environment. Now that we're going to support
+# poetry too, pyproject.toml should include dependencies and the target Python
+# versions. Here's a possible approach for achieving that:
+#
+#   1. Rename this file to pyproject.toml.old.
+#   2. Run "poetry init" to create a new pyproject.toml file.
+#   3. Run "poetry add" commands for any still-absent dependencies/groups.
+#   4. Copy missing parts from pyproject.toml.old to pyproject.toml.
+#   5. Run "poetry install".
+#   6. Run "poetry run python -m unittest". Verify that all tests pass.
+#   7. Make sure the notebooks work when they use the poetry environment.
+#   8. Uncomment "poetry install" in .devcontainer/onCreate.
+#   9. Delete pyproject.toml.old. (Keep the tab open for these directions.)
+#  10. Commit and push to a feature branch. Merge to main via PR.
+#  11. Trigger a new Codespaces prebuild on main.
+#  12. Add poetry-based CI test jobs (via PR). Keep the conda jobs too.
+#  13. Enable Dependabot security updates and transitive version updates.
 
 [tool.poetry]
 name = "EmbeddingScratchwork"


### PR DESCRIPTION
**This is a request to merge commits into the [`poetry`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/poetry) branch, not [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

Our existing `pyproject.toml` isn't really generated by `poetry` and doesn't list dependencies, so `poetry install` in the `onCreate` script would not have the desired effect. That command is therefore commented out right now, and a possible procedure for creating and using a `pyproject.toml` file with `poetry`-managed dependencies is listed in the revised comment in `pyproject.toml`.

This retains full `conda` support, which should not be removed. However, the `base` environment is no longer activated automatically. This is to help avoid accidentally *mixing* `conda` and `poetry` environments in the same running shell at the same time, which behaves unexpectedly. For example, `poetry` commands shouldn't use `python` interpreters in `conda` environments, not even the `base` environment. It remains generally unnecessary to activate the `base` environment, because the `conda` and `mamba` commands remain available, even when no environment is activated. They should not be run when in a `poetry`-managed virtual environment or shell.

*If/when this is merged, a prebuild must then be triggered on the branch it is merged into (the `poetry` branch). Otherwise, an old prebuild (or one for `main`) will be used, which won't work.*