### PR TITLE
Fix too-long lines in a way that clarifies tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,4 +21,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pylint.main]
-disable = ["too-few-public-methods"]
+disable = [
+    "consider-using-f-string",
+    "too-few-public-methods",
+]

--- a/tests/test_cached.py
+++ b/tests/test_cached.py
@@ -65,7 +65,10 @@ class TestDiskCachedEmbedOne(unittest.TestCase):
 
     # Test saving new files
     def test_saves_file_if_not_cached(self):
-        expected_message = f'INFO:embed.cached:{self.name}: saved: {self._path}'
+        expected_message = 'INFO:embed.cached:{name}: saved: {path}'.format(
+            name=self.name,
+            path=self._path,
+        )
 
         with self.assertLogs(logger=cached.__name__) as log_context:
             self.func('hola', data_dir=self._dir_path)
@@ -75,7 +78,11 @@ class TestDiskCachedEmbedOne(unittest.TestCase):
     # Test loading existing files
     def test_loads_file_if_cached(self):
         self._write_fake_data_file()
-        expected_message = f'INFO:embed.cached:{self.name}: loaded: {self._path}'
+
+        expected_message = 'INFO:embed.cached:{name}: loaded: {path}'.format(
+            name=self.name,
+            path=self._path,
+        )
 
         with self.assertLogs(logger=cached.__name__) as log_context:
             self.func('hola', data_dir=self._dir_path)
@@ -85,13 +92,15 @@ class TestDiskCachedEmbedOne(unittest.TestCase):
     # Test different functions access existing files
     def test_saves_file_that_any_implementation_can_load(self):
         self.func('hola', data_dir=self._dir_path)
+        message_format = 'INFO:embed.cached:{name}: loaded: {path}'
 
         for load_func in (cached.embed_one,
                           cached.embed_one_eu,
                           cached.embed_one_req):
             with self.subTest(load_func=load_func):
-                expected_message = (
-                    f'INFO:embed.cached:{load_func.__name__}: loaded: {self._path}'
+                expected_message = message_format.format(
+                    name=load_func.__name__,
+                    path=self._path,
                 )
 
                 with self.assertLogs(logger=cached.__name__) as log_context:


### PR DESCRIPTION
**This is a request to merge commits into the [`cached`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/cached) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

This fixes `flake8` warnings about too-long lines for the expected message strings built in test cases.

Some ways of doing this would make the tests harder to understand, by splitting the formatted strings in arbitrary places. Even if split logically, I think such a split f-string would still be harder to understand, because the message it represents is still a single (long) line of a log.

I've instead written literal strings with placeholders that the `str.format` method substitutes for, which I think makes even clearer than before what *forms* of log messages are expected. These format strings convey *much* of what we are testing for to humans. The new code builds the actual expected log messages from them at whatever time makes most sense for that test, which varies across tests. I think this also provides superior test-case comparability.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/cached-messages) for unit test status.