### PR TITLE
Add some shell-related dev container functionality

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,9 @@
 {
     "image": "mcr.microsoft.com/devcontainers/base:0-bullseye",
+    "features": {
+        "ghcr.io/devcontainers/features/sshd:1": {},
+        "ghcr.io/lukewiwa/features/shellcheck:0": {}
+    },
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,6 +26,7 @@
         "ipynb",
         "Kagan",
         "lionsleep",
+        "lukewiwa",
         "markdownlint",
         "mhutchie",
         "micromamba",


### PR DESCRIPTION
This adds two dev container features:

- The shellcheck command. Currently we run shellcheck automatically on CI but it is not in the dev container. This is the only code analysis tool that we are using but that is absent in the dev container.
- An ssh server. This allows SSHing into the dev container (including when running it in a codespace). The main benefit of this is that it allows an external terminal to be used.

Although these are shell-related, this is really two separate changes. However, it's convenient to test them together, they both require prebuilds to be rebuilt, and introducing them together avoids a merge conflict between them which would otherwise occur.