### PR TITLE
Add h1 heading to cached.ipynb

### DIFF
--- a/notebooks/cached.ipynb
+++ b/notebooks/cached.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Caching embeddings on disk"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},


### PR DESCRIPTION
**This is a request to merge commits into the [`cached`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/cached) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

This adds "Cached embeddings on disk" as a top heading for the notebook about caching on disk. (That notebook previously had no heading.)