### PR TITLE
Put audit hook logic in a new test helper module

### DIFF
--- a/embed/cached.py
+++ b/embed/cached.py
@@ -47,13 +47,13 @@ def _build_path(text_or_texts, data_dir):
 
 def _load_json(path):
     """Load JSON from a file."""
-    with open(path, mode='r+', encoding='utf-8') as file:
+    with open(path, mode='r', encoding='utf-8') as file:
         return json.load(file)
 
 
 def _save_json(path, obj):
     """Save JSON to a file."""
-    with open(path, mode='w', encoding='utf-8') as file:
+    with open(path, mode='x', encoding='utf-8') as file:
         json.dump(obj=obj, fp=file, indent=4)
         file.write('\n')
 

--- a/embed/cached.py
+++ b/embed/cached.py
@@ -47,13 +47,13 @@ def _build_path(text_or_texts, data_dir):
 
 def _load_json(path):
     """Load JSON from a file."""
-    with open(path, mode='r', encoding='utf-8') as file:
+    with open(path, mode='r+', encoding='utf-8') as file:
         return json.load(file)
 
 
 def _save_json(path, obj):
     """Save JSON to a file."""
-    with open(path, mode='x', encoding='utf-8') as file:
+    with open(path, mode='w', encoding='utf-8') as file:
         json.dump(obj=obj, fp=file, indent=4)
         file.write('\n')
 

--- a/tests/_audit.py
+++ b/tests/_audit.py
@@ -1,0 +1,66 @@
+"""Capturing audit events for tests. This uses at most one hook."""
+
+__all__ = ['scoped_listener']
+
+import contextlib
+import sys
+import threading
+
+
+_lock = threading.Lock()
+"""Mutex protecting the table."""
+
+_table = None
+"""Table mapping each event to its listeners, or None if not yet needed."""
+
+
+def _hook(event, args):
+    """Single audit hook used for all events and handlers."""
+    for listener in _table.get(event, default=()):
+        listener(*args)
+
+
+def _subscribe(event, listener):
+    """Attach a detachable listener to an event."""
+    global _table
+
+    with _lock:
+        if _table is None:
+            _table = {}
+            sys.addaudithook(_hook)
+        old_listeners = _table.get(event, default=())
+        _table[event] = (*old_listeners, listener)
+
+
+def _unsubscribe_raise(event, listener):
+    """Raise an exception for an unsuccessful attempt to detach a listener."""
+    raise ValueError(f'{event!r} listener {listener!r} never subscribed')
+
+
+def _unsubscribe(event, listener):
+    """Detach a listener that was attached to an event."""
+    with _lock:
+        if _table is None or (listeners := _table.get(event)) is None:
+            _unsubscribe_raise(event, listener)
+
+        # Work with the sequence in reverse to remove the most recent listener.
+        listeners_reversed = list(reversed(listeners))
+        try:
+            listeners_reversed.remove(listener)
+        except ValueError:
+            _unsubscribe_raise(event, listener)
+
+        if listeners_reversed:
+            _table[event] = tuple(reversed(listeners_reversed))
+        else:
+            del _table[event]
+
+
+@contextlib.contextmanager
+def scoped_listener(event, listener):
+    """Context manager that subscribes and unsubscribes an event listener."""
+    _subscribe(event, listener)
+    try:
+        yield
+    finally:
+        _unsubscribe(event, listener)

--- a/tests/_audit.py
+++ b/tests/_audit.py
@@ -1,6 +1,6 @@
 """Capturing audit events for tests. This uses at most one hook."""
 
-__all__ = ['scoped_listener', 'skip_if_unavailable']
+__all__ = ['extract', 'skip_if_unavailable']
 
 import contextlib
 import sys
@@ -72,13 +72,21 @@ def _unsubscribe(event, listener):
 
 
 @contextlib.contextmanager
-def scoped_listener(event, listener):
+def _listen(event, listener):
     """Context manager that subscribes and unsubscribes an event listener."""
     _subscribe(event, listener)
     try:
         yield
     finally:
         _unsubscribe(event, listener)
+
+
+@contextlib.contextmanager
+def extract(event, extractor):
+    """Context manager that provides a list of custom-extracted even data."""
+    extracts = []
+    with _listen(event, lambda *args: extracts.append(extractor(*args))):
+        yield extracts
 
 
 skip_if_unavailable = unittest.skipIf(

--- a/tests/_audit.py
+++ b/tests/_audit.py
@@ -78,7 +78,7 @@ def _listen(event, listener):
 
 @contextlib.contextmanager
 def extract(event, extractor):
-    """Context manager that provides a list of custom-extracted even data."""
+    """Context manager that provides a list of custom-extracted event data."""
     extracts = []
     with _listen(event, lambda *args: extracts.append(extractor(*args))):
         yield extracts

--- a/tests/_audit.py
+++ b/tests/_audit.py
@@ -1,6 +1,6 @@
 """Capturing audit events for tests. This uses at most one hook."""
 
-__all__ = ['extract', 'skip_if_unavailable']
+__all__ = ['extracting', 'skip_if_unavailable']
 
 import contextlib
 import sys
@@ -67,7 +67,7 @@ def _unsubscribe(event, listener):
 
 
 @contextlib.contextmanager
-def _listen(event, listener):
+def _listening(event, listener):
     """Context manager that subscribes and unsubscribes an event listener."""
     _subscribe(event, listener)
     try:
@@ -77,10 +77,10 @@ def _listen(event, listener):
 
 
 @contextlib.contextmanager
-def extract(event, extractor):
+def extracting(event, extractor):
     """Context manager that provides a list of custom-extracted event data."""
     extracts = []
-    with _listen(event, lambda *args: extracts.append(extractor(*args))):
+    with _listening(event, lambda *args: extracts.append(extractor(*args))):
         yield extracts
 
 

--- a/tests/_audit.py
+++ b/tests/_audit.py
@@ -38,6 +38,7 @@ def _subscribe(event, listener):
         if _table is None:
             _table = {}
             sys.addaudithook(_hook)
+
         old_listeners = _table.get(event, ())
         _table[event] = (*old_listeners, listener)
 

--- a/tests/_audit.py
+++ b/tests/_audit.py
@@ -16,7 +16,16 @@ _table = None
 
 def _hook(event, args):
     """Single audit hook used for all events and handlers."""
-    for listener in _table.get(event, default=()):
+    try:
+        # For performance, don't lock. Subscripting a dict with str keys should
+        # be sufficiently protected by the GIL in CPython. This doesn't protect
+        # the table rows. But those are tuples that we always replace, rather
+        # than lists that we mutate, so we should observe consistent state.
+        listeners = _table[event]
+    except KeyError:
+        return
+
+    for listener in listeners:
         listener(*args)
 
 

--- a/tests/_audit.py
+++ b/tests/_audit.py
@@ -4,12 +4,8 @@ __all__ = ['extract', 'skip_if_unavailable']
 
 import contextlib
 import sys
-import threading
 import unittest
 
-
-_lock = threading.Lock()
-"""Mutex protecting the table."""
 
 _table = None
 """Table mapping each event to its listeners, or None if not yet needed."""
@@ -18,10 +14,10 @@ _table = None
 def _hook(event, args):
     """Single audit hook used for all events and handlers."""
     try:
-        # For performance, don't lock. Subscripting a dict with str keys should
-        # be sufficiently protected by the GIL in CPython. This doesn't protect
-        # the table rows. But those are tuples that we always replace, rather
-        # than lists that we mutate, so we should observe consistent state.
+        # Subscripting a dict with str keys should be sufficiently protected by
+        # the GIL in CPython. This doesn't protect the table rows. But those
+        # are tuples that we always replace, rather than lists that we mutate,
+        # so we should observe consistent state.
         listeners = _table[event]
     except KeyError:
         return
@@ -34,13 +30,12 @@ def _subscribe(event, listener):
     """Attach a detachable listener to an event."""
     global _table
 
-    with _lock:
-        if _table is None:
-            _table = {}
-            sys.addaudithook(_hook)
+    if _table is None:
+        _table = {}
+        sys.addaudithook(_hook)
 
-        old_listeners = _table.get(event, ())
-        _table[event] = (*old_listeners, listener)
+    old_listeners = _table.get(event, ())
+    _table[event] = (*old_listeners, listener)
 
 
 def _fail_unsubscribe(event, listener):
@@ -50,26 +45,25 @@ def _fail_unsubscribe(event, listener):
 
 def _unsubscribe(event, listener):
     """Detach a listener that was attached to an event."""
-    with _lock:
-        if _table is None:
-            _fail_unsubscribe(event, listener)
+    if _table is None:
+        _fail_unsubscribe(event, listener)
 
-        try:
-            listeners = _table[event]
-        except KeyError:
-            _fail_unsubscribe(event, listener)
+    try:
+        listeners = _table[event]
+    except KeyError:
+        _fail_unsubscribe(event, listener)
 
-        # Work with the sequence in reverse to remove the most recent listener.
-        listeners_reversed = list(reversed(listeners))
-        try:
-            listeners_reversed.remove(listener)
-        except ValueError:
-            _fail_unsubscribe(event, listener)
+    # Work with the sequence in reverse to remove the most recent listener.
+    listeners_reversed = list(reversed(listeners))
+    try:
+        listeners_reversed.remove(listener)
+    except ValueError:
+        _fail_unsubscribe(event, listener)
 
-        if listeners_reversed:
-            _table[event] = tuple(reversed(listeners_reversed))
-        else:
-            del _table[event]
+    if listeners_reversed:
+        _table[event] = tuple(reversed(listeners_reversed))
+    else:
+        del _table[event]
 
 
 @contextlib.contextmanager

--- a/tests/_audit.py
+++ b/tests/_audit.py
@@ -1,10 +1,11 @@
 """Capturing audit events for tests. This uses at most one hook."""
 
-__all__ = ['scoped_listener']
+__all__ = ['scoped_listener', 'skip_if_unavailable']
 
 import contextlib
 import sys
 import threading
+import unittest
 
 
 _lock = threading.Lock()
@@ -37,7 +38,7 @@ def _subscribe(event, listener):
         if _table is None:
             _table = {}
             sys.addaudithook(_hook)
-        old_listeners = _table.get(event, default=())
+        old_listeners = _table.get(event, ())
         _table[event] = (*old_listeners, listener)
 
 
@@ -78,3 +79,10 @@ def scoped_listener(event, listener):
         yield
     finally:
         _unsubscribe(event, listener)
+
+
+skip_if_unavailable = unittest.skipIf(
+    sys.version_info < (3, 8),
+    'sys.addaudithook introduced in Python 3.8',
+)
+"""Skip a ``unittest`` test if audit event functionality is unavailable."""

--- a/tests/test_cached.py
+++ b/tests/test_cached.py
@@ -130,7 +130,7 @@ class TestDiskCachedEmbedOne(unittest.TestCase):
         self._write_fake_data_file()
         expected_open_event = _OpenEvent(str(self._path), 'r')
 
-        with _audit.extract('open', _OpenEvent.from_args) as open_events:
+        with _audit.extracting('open', _OpenEvent.from_args) as open_events:
             self.func('hola', data_dir=self._dir_path)
 
         self.assertIn(expected_open_event, open_events)
@@ -141,7 +141,7 @@ class TestDiskCachedEmbedOne(unittest.TestCase):
         # TODO: Decide whether to keep allowing just 'x', or if 'w' is OK too.
         expected_open_event = _OpenEvent(str(self._path), 'x')
 
-        with _audit.extract('open', _OpenEvent.from_args) as open_events:
+        with _audit.extracting('open', _OpenEvent.from_args) as open_events:
             self.func('hola', data_dir=self._dir_path)
 
         self.assertIn(expected_open_event, open_events)

--- a/tests/test_cached.py
+++ b/tests/test_cached.py
@@ -117,7 +117,7 @@ class TestDiskCachedEmbedOne(unittest.TestCase):
 
     # Test for load auditing event
     @_audit.skip_if_unavailable
-    def test_for_load_audit_event(self):
+    def test_load_confirmed_by_audit_event(self):
         self._write_fake_data_file()
         expected_open_event = _OpenEvent(str(self._path), 'r')
 
@@ -127,6 +127,15 @@ class TestDiskCachedEmbedOne(unittest.TestCase):
         self.assertIn(expected_open_event, open_events)
 
     # Test for save auditing event
+    @_audit.skip_if_unavailable
+    def test_save_confirmed_by_audit_event(self):
+        # TODO: Decide whether to keep allowing just 'x', or if 'w' is OK too.
+        expected_open_event = _OpenEvent(str(self._path), 'x')
+
+        with _audit.extract('open', _OpenEvent.from_args) as open_events:
+            self.func('hola', data_dir=self._dir_path)
+
+        self.assertIn(expected_open_event, open_events)
 
     # Test file is created when should save
     def test_saved_embedding_exists(self):

--- a/tests/test_cached.py
+++ b/tests/test_cached.py
@@ -162,8 +162,6 @@ class TestDiskCachedEmbedOne(unittest.TestCase):
             wraps=getattr(embed, self.name),
         )
 
-    # FIXME: Add _record_open_events @contextlib.contextmanager helper method.
-
 
 # FIXME: Finish writing most or all of this module's tests. Roughly speaking:
 #

--- a/tests/test_cached.py
+++ b/tests/test_cached.py
@@ -24,12 +24,12 @@ import embed
 from embed import cached
 from tests import _audit, _helpers
 
-_helpers.configure_logging()
-
 _HOLA_FILENAME = (
     'b58e4a60c963f8b3c43d83cc9245020ce71d8311fa2f48cfd36deed6f472a71b.json'
 )
 """Filename that would be generated from the input ``'hola'``."""
+
+_helpers.configure_logging()
 
 
 @attrs.frozen


### PR DESCRIPTION
**This is a request to merge commits into the [`cached`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/cached) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

This uses a single audit hook for all observations of the `input` auditing event in our test suite. (Currently we are using three, due to the effects of test class parameterization.) It also separates it from the logic ot the tests themselves, putting it in a new test helper module, `_audit`.

This also adds the second of two test cases in `test_cached` that checks audit events.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/cached-hooks) for unit test status.