### PR TITLE
Improve interface of disk-caching helper

### DIFF
--- a/embed/cached.py
+++ b/embed/cached.py
@@ -57,8 +57,8 @@ def _save_json(path, obj):
         file.write('\n')
 
 
-def _cache_on_disk(text_or_texts, *, data_dir, func):
-    """Helper function to add disk caching to an embedding function."""
+def _embed_with_disk_caching(func, text_or_texts, data_dir):
+    """Load cached embeddings from disk, or compute and save them."""
     path = _build_path(text_or_texts, data_dir)
     try:
         parsed = _load_json(path)
@@ -75,33 +75,33 @@ def _cache_on_disk(text_or_texts, *, data_dir, func):
 
 def embed_one(text, *, data_dir=None):
     """Embed a single piece of text. Caches to disk."""
-    return _cache_on_disk(text, data_dir=data_dir, func=embed.embed_one)
+    return _embed_with_disk_caching(embed.embed_one, text, data_dir)
 
 
 def embed_many(texts, *, data_dir=None):
     """Embed multiple pieces of text. Caches to disk."""
-    return _cache_on_disk(texts, data_dir=data_dir, func=embed.embed_many)
+    return _embed_with_disk_caching(embed.embed_many, texts, data_dir)
 
 
 def embed_one_eu(text, *, data_dir=None):
     """
     Embed a single piece of text. Uses ``embeddings_utils``. Caches to disk.
     """
-    return _cache_on_disk(text, data_dir=data_dir, func=embed.embed_one_eu)
+    return _embed_with_disk_caching(embed.embed_one_eu, text, data_dir)
 
 
 def embed_many_eu(texts, *, data_dir=None):
     """
     Embed multiple pieces of text. Uses ``embeddings_utils``. Caches to disk.
     """
-    return _cache_on_disk(texts, data_dir=data_dir, func=embed.embed_many_eu)
+    return _embed_with_disk_caching(embed.embed_many_eu, texts, data_dir)
 
 
 def embed_one_req(text, *, data_dir=None):
     """Embed a single piece of text. Uses ``requests``. Caches to disk."""
-    return _cache_on_disk(text, data_dir=data_dir, func=embed.embed_one_req)
+    return _embed_with_disk_caching(embed.embed_one_req, text, data_dir)
 
 
 def embed_many_req(texts, *, data_dir=None):
     """Embed multiple pieces of text. Uses ``requests``. Caches to disk."""
-    return _cache_on_disk(texts, data_dir=data_dir, func=embed.embed_many_req)
+    return _embed_with_disk_caching(embed.embed_many_req, texts, data_dir)


### PR DESCRIPTION
**This is a request to merge commits into the [`cached`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/cached) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

The function currently named `_cache_on_disk` currently retains some characteristics that made sense with the old decorator approach, but don't really make sense anymore.

(This is the function that does the work of checking for saved embeddings, and if there isn't one, calling an `embed.embed_*` function and saving the result.)

This PR makes three improvements, addressing that.

1. Change the name to something that makes more sense for what it does now.
2. Fix the docstring, which still described it like the old decorator.
3. Use an argument order that is more intuitive and better resembles how functions are called.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/cached-helper) for unit test status.