### PR TITLE
Suppress some pylint warnings; improve fixme style

### DIFF
--- a/tests/_audit.py
+++ b/tests/_audit.py
@@ -8,10 +8,10 @@ import unittest
 
 import attrs
 
-_hooked = False
+_hooked = False  # pylint: disable=invalid-name  # Not a constant.
 """Whether the audit hook has been installed."""
 
-_open_events = None
+_open_events = None  # pylint: disable=invalid-name  # Not a constant.
 """The current event collector list. ``None``, whenever not collecting."""
 
 
@@ -44,6 +44,8 @@ def _hook(event, args):
 @contextlib.contextmanager
 def listening_for_open():
     """Context manager to collect information on open events in a list."""
+    # pylint: disable=global-statement
+    # We really do want to mutate this shared state maintained at module level.
     global _hooked, _open_events
 
     if not _hooked:

--- a/tests/test_cached.py
+++ b/tests/test_cached.py
@@ -68,7 +68,7 @@ class TestDiskCachedEmbedOne(unittest.TestCase):
         """Delete the temporary directory."""
         self._temporary_directory.cleanup()
 
-    # FIXME: Test returned embeddings could plausibly be correct.
+    # FIXME: Test that returned embeddings could plausibly be correct.
 
     def test_calls_same_name_non_caching_version_if_not_cached(self):
         with _patch_non_disk_caching_embedder(self.name) as mock:
@@ -191,7 +191,7 @@ class TestDiskCachedEmbedMany(unittest.TestCase):
         """Delete the temporary directory."""
         self._temporary_directory.cleanup()
 
-    # FIXME: Test returned embeddings could plausibly be correct
+    # FIXME: Test that returned embeddings could plausibly be correct.
 
     def test_calls_same_name_non_caching_version_if_not_cached(self):
         with _patch_non_disk_caching_embedder(self.name) as mock:


### PR DESCRIPTION
The `pylint` annotations shown here are not about new problems. They are due to FIXMEs changing (which is treated the same as if they were replaced by new FIXMEs).