### PR TITLE
Pass exception info to __exit__ in cleanup

### DIFF
--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -6,6 +6,7 @@
 # All test methods have self-documenting names.
 
 from abc import ABC, abstractmethod
+import sys
 import unittest
 
 import numpy as np
@@ -32,7 +33,7 @@ class _TestEmbedBase(ABC, unittest.TestCase):
 
         self.addCleanup(
             _helpers.maybe_cache_embeddings_in_memory.__exit__,
-            None, None, None,
+            *sys.exc_info(),
         )
 
     @property


### PR DESCRIPTION
**This is a request to merge commits into the [`tests`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/tests) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

Currently, the context manager we are using does not differentiate (I think at all, but at least not in a way that is important) between exiting its context normally vs. due to an exception. So with the other code as it currently stands, this shouldn't produce a behavioral change.

However, this code is less brittle, and it is possible to verify its correctness without knowing about the details of the context manager we're using. It's fairly simple, and `sys.exc_info` is an idiomatic way to access this information. (It's even slightly shorter than the code we had before.)

If we end up extracting this logic to an ever deeper base class, then we'll benefit from not having to reason about whether it correctly handles cleanup every time. So one benefit of this change is to remove a blocker for that, *if* we end up wanting to do it. But I think this can be considered an improvement (albeit a more modest one) even if we assume the code won't be reused any further.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/tests-exc) for unit test status.