### PR TITLE
Add missing extensions we use to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,9 +7,11 @@
     "customizations": {
         "vscode": {
             "extensions": [
+                "alefragnani.numbered-bookmarks",
                 "bierner.markdown-preview-github-styles",
                 "eamodio.gitlens",
                 "GitHub.vscode-github-actions",
+                "GitHub.vscode-pull-request-github",
                 "mhutchie.git-graph",
                 "ms-python.python",
                 "MS-vsliveshare.vsliveshare",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "cSpell.language": "en,es",
     "cSpell.words": [
         "addaudithook",
+        "alefragnani",
         "autobuild",
         "backoff",
         "bewuethr",


### PR DESCRIPTION
This adds two extensions to the dev container configuration:

- GitHub Pull Requests and Issues (sometimes installed in our codespaces for other reasons)
- Numbered Bookmarks (currently not available in our codespaces)