### PR TITLE
Fix broken link and module name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,14 @@ OpenAI’s servers.
 
 ### Major Modules (Tests)
 
+<!-- FIXME: Update this again when all new test modules have been created. -->
+
 [`test_embed`](tests/test_embed.py) has automated tests of the functions in
 `embed`. This includes testing that some examples’ similarities are within
 expected ranges.
 
-[`test_cached`](tests/test_cached.py) has automated tests specific to
-functionality in `embed.cached`.
+[`test_cached_caching`](tests/test_cached_caching.py) has automated tests
+*specific* to functionality in `embed.cached`.
 
 ### Notebooks
 


### PR DESCRIPTION
**This is a request to merge commits into the [`tests`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/tests) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

This fixes the readme, which became outdated because `test_cached.py` has been renamed to `test_cached_caching.py`.

The Markdown link check should pass now.