### PR TITLE
Add super().setUp() and super().tearDown() calls

### DIFF
--- a/tests/_bases.py
+++ b/tests/_bases.py
@@ -17,6 +17,8 @@ class TestEmbedBase(ABC, unittest.TestCase):
     """Abstract base to provide helpers and fixtures."""
 
     def setUp(self):
+        super().setUp()
+
         _helpers.maybe_cache_embeddings_in_memory.__enter__()
 
         self.addCleanup(
@@ -114,7 +116,7 @@ class TestDiskCachedBase(TestEmbedBase):
         self._temporary_directory = tempfile.TemporaryDirectory()
         self._dir_path = pathlib.Path(self._temporary_directory.name)
 
-    def tearDown(self):
+    def tearDown(self):  # FIXME: Do this with addCleanup in setUp instead.
         """Delete the temporary directory."""
         self._temporary_directory.cleanup()
         super().tearDown()

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -81,6 +81,8 @@ class TestBackoff(unittest.TestCase):
 
     def setUp(self):
         """Help us avoid running the test on CI, and decrease stack size."""
+        super().setUp()
+
         if 'CI' in os.environ:
             # pylint: disable=broad-exception-raised  # Error that blocks test.
             raise Exception(
@@ -91,9 +93,10 @@ class TestBackoff(unittest.TestCase):
         _logger.warning(
             "Running full backoff test, which shouldn't usually be done.")
 
-    def tearDown(self):
+    def tearDown(self):  # FIXME: Do this with addCleanup from setUp instead.
         """Restore the stack size."""
         threading.stack_size(self._old_stack_size)
+        super().tearDown()
 
     def test_embed_one_req_backs_off(self):
         """``embed_one_req`` backs off under high load and logs that it did."""

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -18,6 +18,8 @@ class TestApiKey(unittest.TestCase):
 
     def setUp(self):
         """Save api_key attributes. Also pre-patch them, for log redaction."""
+        super().setUp()
+
         # This cannot be done straightforwardly with unittest.mock.patch
         # because that expects to be able to delete attributes, and the
         # embed.api_key property (deliberately) has no deleter.
@@ -26,10 +28,12 @@ class TestApiKey(unittest.TestCase):
         openai.api_key = 'sk-fake-redact-outer'
         embed.api_key = 'sk-fake-redact-inner'
 
-    def tearDown(self):
+    def tearDown(self):  # FIXME: Do this with addCleanup from setUp instead.
         """Unpatch api_key attributes."""
         embed.api_key = self._real_key_embed
         openai.api_Key = self._real_key_openai
+
+        super().tearDown()
 
     @parameterized.expand([
         ('str', 'sk-fake-setting-sets'),


### PR DESCRIPTION
**This is a request to merge commits into the [`tests`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/tests) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

This calls `setUp` and `tearDown` through `super` proxies in all our existing `setUp` and `tearDown` methods, in all our test classes that have them.

It also adds fixme comments stating a plan to use `addCleanup` everywhere instead of `tearDown`. I'm of course willing to remove or weaken those fixmes, if you like.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/tests-super) for unit test status.