### PR TITLE
Improve test base organization and documentation

### DIFF
--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -30,7 +30,7 @@ import unittest
 
 import backoff
 
-from tests import _helpers
+from tests import _bases, _helpers
 import embed
 
 _STACK_SIZE = 32_768
@@ -41,8 +41,6 @@ _BATCH_COUNT = 600
 
 _BATCH_SIZE = 8
 """Number of requests each batch makes sequentially in the backoff test."""
-
-_helpers.configure_logging()
 
 _logger = logging.getLogger(__name__)
 """Logger for messages from this test module."""
@@ -68,7 +66,7 @@ def _run_batch(batch_index):
     _helpers.getenv_bool('TESTS_RUN_BACKOFF_TEST_I_KNOW_WHAT_I_AM_DOING'),
     "No need to regularly slam OpenAI's servers. Also: very slow.",
 )
-class TestBackoff(unittest.TestCase):
+class TestBackoff(_bases.TestBase):
     """
     Test backoff in one of the functions using ``requests`` (``test_one_req``).
 

--- a/tests/test_cached_caching.py
+++ b/tests/test_cached_caching.py
@@ -7,9 +7,6 @@ Those embedding functions are the versions that cache to disk. They are
 otherwise like the same-named functions residing directly in ``embed``.
 """
 
-# pylint: disable=missing-function-docstring
-# All test methods have self-documenting names.
-
 from abc import abstractmethod
 import json
 import unittest
@@ -17,7 +14,7 @@ from unittest.mock import patch
 
 import embed
 from embed import cached
-from tests import _audit, _bases, _helpers
+from tests import _audit, _bases
 
 _HOLA_FILENAME = (
     'b58e4a60c963f8b3c43d83cc9245020ce71d8311fa2f48cfd36deed6f472a71b.json'
@@ -28,8 +25,6 @@ _HOLA_HELLO_FILENAME = (
     '4a77f419587b08963e94105b8b9272531e53ade9621b613fda175aa0a96cd839.json'
 )
 """Filename that would be generated from the input ``['hola', 'hello']``."""
-
-_helpers.configure_logging()
 
 
 class _TestDiskCachedCachingBase(_bases.TestDiskCachedBase):
@@ -66,7 +61,7 @@ class _TestDiskCachedCachingBase(_bases.TestDiskCachedBase):
     def func(self):
         """Disk caching embedding function being tested."""
 
-    # FIXME: Test that returned embeddings could plausibly be correct.
+    # pylint: disable=missing-function-docstring  # Tests' names describe them.
 
     def test_calls_same_name_non_caching_version_if_not_cached(self):
         with self._patch_non_disk_caching_embedder() as mock:

--- a/tests/test_cached_embeddings.py
+++ b/tests/test_cached_embeddings.py
@@ -41,7 +41,6 @@ class _TestDiskCacheHitBase(_TestDiskCacheEmbeddingsBase):
             shutil.copy(path, self._dir_path)
 
 
-
 class TestDiskCacheHitEmbedOne(
     _bases.TestEmbedOneBase,
     _TestDiskCacheHitBase,

--- a/tests/test_cached_embeddings.py
+++ b/tests/test_cached_embeddings.py
@@ -12,7 +12,9 @@ import shutil
 import unittest
 
 from embed import cached
-from tests import _bases
+from tests import _bases, _helpers
+
+_helpers.configure_logging()
 
 
 class _TestDiskCacheEmbeddingsBase(_bases.TestDiskCachedBase):

--- a/tests/test_cached_embeddings.py
+++ b/tests/test_cached_embeddings.py
@@ -12,9 +12,7 @@ import shutil
 import unittest
 
 from embed import cached
-from tests import _bases, _helpers
-
-_helpers.configure_logging()
+from tests import _bases
 
 
 class _TestDiskCacheEmbeddingsBase(_bases.TestDiskCachedBase):

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -7,26 +7,22 @@ This consists mostly of tests of embeddings from ``embed.embed*`` functions.
 This does not test the disk caching versions; see ``test_cached_embeddings``.
 """
 
-# pylint: disable=missing-function-docstring
-# All test methods have self-documenting names.
-
 import unittest
 
 import embed
-from tests import _bases, _helpers
-
-_helpers.configure_logging()
+from tests import _bases
 
 
-class TestConstants(unittest.TestCase):
+class TestConstants(_bases.TestBase):
     """Tests for public constants in ``embed``."""
 
     def test_model_dimension_is_1536(self):
+        """``DIMENSION``'s value is correct for ``text-embedding-ada-002``."""
         self.assertEqual(embed.DIMENSION, 1536)
 
 
 class TestEmbedOne(_bases.TestEmbedOneBase):
-    """Tests for ``embed_one``."""
+    """Tests for the non-disk-caching ``embed_one``."""
 
     @property
     def func(self):
@@ -34,7 +30,7 @@ class TestEmbedOne(_bases.TestEmbedOneBase):
 
 
 class TestEmbedOneEu(_bases.TestEmbedOneBase):
-    """Tests for ``embed_one_eu``."""
+    """Tests for the non-disk-caching ``embed_one_eu``."""
 
     @property
     def func(self):
@@ -42,7 +38,7 @@ class TestEmbedOneEu(_bases.TestEmbedOneBase):
 
 
 class TestEmbedOneReq(_bases.TestEmbedOneBase):
-    """Tests for ``embed_one_req``."""
+    """Tests for the non-disk-caching ``embed_one_req``."""
 
     @property
     def func(self):
@@ -50,7 +46,7 @@ class TestEmbedOneReq(_bases.TestEmbedOneBase):
 
 
 class TestEmbedMany(_bases.TestEmbedManyBase):
-    """Tests for ``embed_many``."""
+    """Tests for the non-disk-caching ``embed_many``."""
 
     @property
     def func(self):
@@ -58,7 +54,7 @@ class TestEmbedMany(_bases.TestEmbedManyBase):
 
 
 class TestEmbedManyEu(_bases.TestEmbedManyBase):
-    """Tests for ``embed_many_eu``."""
+    """Tests for the non-disk-caching ``embed_many_eu``."""
 
     @property
     def func(self):
@@ -66,7 +62,7 @@ class TestEmbedManyEu(_bases.TestEmbedManyBase):
 
 
 class TestEmbedManyReq(_bases.TestEmbedManyBase):
-    """Tests for ``embed_many_req``."""
+    """Tests for the non-disk-caching ``embed_many_req``."""
 
     @property
     def func(self):

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -8,12 +8,10 @@ import openai
 from parameterized import parameterized
 
 import embed
-from tests import _helpers
-
-_helpers.configure_logging()
+from tests import _bases
 
 
-class TestApiKey(unittest.TestCase):
+class TestApiKey(_bases.TestBase):
     """Tests for ``embed.api_key``."""
 
     def setUp(self):


### PR DESCRIPTION
Fixes #96 (see point 3 below)

**This is a request to merge commits into the [`tests`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/tests) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

This makes several only moderately interrelated changes in test code that are easy to do together while staying out of the way of work being done in `test_cached_embedding.py`.

https://github.com/dmvassallo/EmbeddingScratchwork/pull/93/commits/89ed1cbd8fbd0b9215595face4705508d9968443 removes an excess blank line in that file. Although https://github.com/dmvassallo/EmbeddingScratchwork/pull/93/commits/deab71eea9951ef6910377952e3bf52922fb4f53 changed code there, other changes in https://github.com/dmvassallo/EmbeddingScratchwork/pull/93/commits/f3381bc9988a9ac582939dcc66da6094d9f60347 made that change unnecessary and removed it, so the [overall change](https://github.com/dmvassallo/EmbeddingScratchwork/pull/93/files#diff-cb6baa0fa7275627843f76aab0ec87fa08ca5128773e7a788209fe262cf6b817) in `test_cached_embedding.py` is just the removal of a blank line.

The significant changes in this PR, compared to its base branch [`tests`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/tests), are:

1. **Update class and method docstrings, and add some missing ones.**

   This includes making the distinction between the purposes of on-disk caching (a feature of the code under test) and in-memory caching (a feature of the test suite itself) in `TestEmbedBase`, which is the base class that supplies the fixture to do the patching for in-memory caching.

   This also includes updating class docstrings for classes formerly in `test_embed.py`, which still said they were only for the non-disk-caching versions. Those classes have since come to be inherited from in `test_cache_embeddings.py`, so they are also testing disk-caching versions.

2. **Reorder the existing classes in `_bases.py`**, so those that provide only fixtures but do not (even indirectly) provide test cases are together, followed by the classes that provide test cases.

3. **Add a base class for all test classes in the project**, and call `configure_logging` in it, removing all other `configure_logging` calls everywhere. (With more modules, the weight of the duplication is greater, and also it is easier to forget to add the call: [**we didn't have it in `test_cached_embeddings.py`**](https://github.com/dmvassallo/EmbeddingScratchwork/pull/93/commits/deab71eea9951ef6910377952e3bf52922fb4f53).) It is called in a way that ensures logging is configured before any test runs, including before any `setUp` fixture runs.

   Currently, that's all this shared base does, but it will also be a good place to conditionally define [`enterContext`](https://docs.python.org/3/library/unittest.html#unittest.TestCase.enterContext). (See the TODO about that, in the class.)

   All classes in the project that had previously inherited directly from `unittest.TestCase` now inherit directly from `_bases.TestBase` instead. (`_bases.TestBase` of course itself inherits directly from `unittest.TestCase`.)

4. **Change how `pylint`'s `missing-function-docstring` diagnostic is suppressed** for test methods with self-documenting names. This moves the comments into the relevant classes and puts them before the first test method in each class. This is more fine-grained because `pylint` takes them to refer only to the code in the class after that point, rather than code everywhere in the module.

   This also takes care of suppressing that diagnostic in one place where a suppression was missing (due to the comments not being updated in the partially completed reorganization).

5. **Remove the "Test that returned embeddings could plausibly be correct" FIXME**, because the work currently under way in `tests_cached_embeddings.py` takes care of that, and more.

6. **Add a TODO to split `_bases.py` into multiple modules.**

See [**my branch**](https://github.com/EliahKagan/EmbeddingScratchwork/commits/tests-next) for unit test status.