### PR TITLE
Make audit event handling shorter and nicer

### DIFF
--- a/embed/cached.py
+++ b/embed/cached.py
@@ -46,13 +46,13 @@ def _build_path(text_or_texts, data_dir):
 
 def _load_json(path):
     """Load JSON from a file."""
-    with open(path, mode='r+', encoding='utf-8') as file:
+    with open(path, mode='r', encoding='utf-8') as file:
         return json.load(file)
 
 
 def _save_json(path, obj):
     """Save JSON to a file."""
-    with open(path, mode='w', encoding='utf-8') as file:
+    with open(path, mode='x', encoding='utf-8') as file:
         json.dump(obj=obj, fp=file, indent=4)
         file.write('\n')
 

--- a/embed/cached.py
+++ b/embed/cached.py
@@ -46,13 +46,13 @@ def _build_path(text_or_texts, data_dir):
 
 def _load_json(path):
     """Load JSON from a file."""
-    with open(path, mode='r', encoding='utf-8') as file:
+    with open(path, mode='r+', encoding='utf-8') as file:
         return json.load(file)
 
 
 def _save_json(path, obj):
     """Save JSON to a file."""
-    with open(path, mode='x', encoding='utf-8') as file:
+    with open(path, mode='w', encoding='utf-8') as file:
         json.dump(obj=obj, fp=file, indent=4)
         file.write('\n')
 

--- a/tests/_audit.py
+++ b/tests/_audit.py
@@ -1,65 +1,47 @@
 """Capturing ``open`` audit events for tests. This uses at most one hook."""
 
-__all__ = ['OpenEvent', 'listening_for_open', 'skip_if_unavailable']
+__all__ = ['listening_for_open', 'skip_if_unavailable']
 
 import contextlib
 import sys
 import unittest
-
-import attrs
+import unittest.mock
 
 _hooked = False  # pylint: disable=invalid-name  # Not a constant.
 """Whether the audit hook has been installed."""
 
-_open_events = None  # pylint: disable=invalid-name  # Not a constant.
-"""The current event collector list. ``None``, whenever not collecting."""
-
-
-@attrs.frozen
-class OpenEvent:
-    """The information from an ``open`` event that we make assertions about."""
-
-    path = attrs.field()
-    """The ``path`` argument in an ``open`` audit event."""
-
-    mode = attrs.field()
-    """The ``mode`` argument in an ``open`` audit event."""
-
-    @classmethod
-    def from_args(cls, path, mode, _):
-        """Create from the actual audit event arguments. Discards ``flags``."""
-        return cls(path, mode)
+_listener_for_open = None  # pylint: disable=invalid-name  # Not a constant.
+"""The current listener that ``open`` event args are passed to, or ``None``."""
 
 
 def _hook(event, args):
     """Auditing event hook that conditionally reports ``open`` events."""
     if event != 'open':
         return
-    open_events = _open_events  # Copy reference to avoid race condition.
-    if open_events is None:
-        return
-    open_events.append(OpenEvent.from_args(*args))
+    listener = _listener_for_open  # Copy reference to avoid race condition.
+    if _listener_for_open is not None:
+        listener(*args)
 
 
 @contextlib.contextmanager
 def listening_for_open():
-    """Context manager to collect information on open events in a list."""
+    """Context manager to pass ``open`` event args to a call-recording mock."""
     # pylint: disable=global-statement
     # We really do want to mutate this shared state maintained at module level.
-    global _hooked, _open_events
+    global _hooked, _listener_for_open
 
     if not _hooked:
         _hooked = True
         sys.addaudithook(_hook)
 
-    if _open_events is not None:
+    if _listener_for_open is not None:
         raise RuntimeError(f'{listening_for_open.__name__} is not reentrant')
 
-    _open_events = []
+    _listener_for_open = unittest.mock.Mock()
     try:
-        yield _open_events
+        yield _listener_for_open
     finally:
-        _open_events = None
+        _listener_for_open = None
 
 
 skip_if_unavailable = unittest.skipIf(

--- a/tests/_audit.py
+++ b/tests/_audit.py
@@ -18,7 +18,7 @@ def _hook(event, args):
     if event != 'open':
         return
     listener = _listener  # Copy reference to avoid race condition.
-    if _listener is not None:
+    if listener is not None:
         listener(*args)
 
 

--- a/tests/test_cached_caching.py
+++ b/tests/test_cached_caching.py
@@ -13,7 +13,7 @@ otherwise like the same-named functions residing directly in ``embed``.
 from abc import abstractmethod
 import json
 import unittest
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, Mock, patch
 
 import embed
 from embed import cached
@@ -118,14 +118,14 @@ class _TestDiskCachedCachingBase(_bases.TestDiskCachedBase):
     def test_load_confirmed_by_audit_event(self):
         self._write_fake_data_file()
 
-        with _audit.listening_for_open() as listener:
+        with _audit.listening_for_open(Mock()) as listener:
             self.func(self.text_or_texts, data_dir=self._dir_path)
 
         listener.assert_any_call(str(self._path), 'r', ANY)
 
     @_audit.skip_if_unavailable
     def test_save_confirmed_by_audit_event(self):
-        with _audit.listening_for_open() as listener:
+        with _audit.listening_for_open(Mock()) as listener:
             self.func(self.text_or_texts, data_dir=self._dir_path)
 
         # TODO: Decide whether to keep allowing just 'x', or if 'w' is OK too.

--- a/tests/test_cached_caching.py
+++ b/tests/test_cached_caching.py
@@ -13,7 +13,7 @@ otherwise like the same-named functions residing directly in ``embed``.
 from abc import abstractmethod
 import json
 import unittest
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import embed
 from embed import cached
@@ -117,22 +117,19 @@ class _TestDiskCachedCachingBase(_bases.TestDiskCachedBase):
     @_audit.skip_if_unavailable
     def test_load_confirmed_by_audit_event(self):
         self._write_fake_data_file()
-        expected_open_event = _audit.OpenEvent(str(self._path), 'r')
 
-        with _audit.listening_for_open() as open_events:
+        with _audit.listening_for_open() as listener:
             self.func(self.text_or_texts, data_dir=self._dir_path)
 
-        self.assertIn(expected_open_event, open_events)
+        listener.assert_any_call(str(self._path), 'r', ANY)
 
     @_audit.skip_if_unavailable
     def test_save_confirmed_by_audit_event(self):
-        # TODO: Decide whether to keep allowing just 'x', or if 'w' is OK too.
-        expected_open_event = _audit.OpenEvent(str(self._path), 'x')
-
-        with _audit.listening_for_open() as open_events:
+        with _audit.listening_for_open() as listener:
             self.func(self.text_or_texts, data_dir=self._dir_path)
 
-        self.assertIn(expected_open_event, open_events)
+        # TODO: Decide whether to keep allowing just 'x', or if 'w' is OK too.
+        listener.assert_any_call(str(self._path), 'x', ANY)
 
     def test_saved_embedding_exists(self):
         self.func(self.text_or_texts, data_dir=self._dir_path)


### PR DESCRIPTION
**This is a request to merge commits into the [`tests`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/tests) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

This uses a [`Mock`](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock) as a listener and [asserts a call](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock.assert_any_call) of the correct form.

In an ideal world (for our tests), it would be possible to subscribe and unsubscribe listeners for specific audit events, which would be called with the event's `args` (as separate arguments). We could just subscribe a `unittest.mock.Mock` object, and use its method for asserting that it was called at least once with the correct values of the arguments we're interested in and any value of the argument we're not interested in.

This commit changes the `_audit` submodule so that it allows the test code to work that way. Extracting to a list is unnecessary, as is picking out which arguments we want and choosing a data structure to represent them; the key insight here, which I hadn't had when I wrote previous versions of our audit event checking code, is that `unittest.mock.Mock` objects basically do those two things for us.

The `flake8` CI check failure is due to an extra blank line (fixed in #93) in a file this PR does not modify. See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/tests-hook) for unit test status.