### PR TITLE
Use enterContext

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
         "devcontainers",
         "dogwalk",
         "dtype",
+        "dunder",
         "eamodio",
         "Eliah",
         "embedder",

--- a/embed/cached.py
+++ b/embed/cached.py
@@ -14,14 +14,14 @@ __all__ = [
 
 import json
 import logging
-import pathlib
+from pathlib import Path
 
 import blake3
 import numpy as np
 
 import embed
 
-DEFAULT_DATA_DIR = pathlib.Path('data')
+DEFAULT_DATA_DIR = Path('data')
 """Default directory to cache embeddings."""
 
 _logger = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ def _build_path(text_or_texts, data_dir):
 
     serialized_data = json.dumps(text_or_texts).encode()
     basename = _compute_blake3_hash(serialized_data).hexdigest()
-    return pathlib.Path(data_dir, f'{basename}.json')  # data_dir may be a str.
+    return Path(data_dir, f'{basename}.json')  # data_dir may be a str.
 
 
 def _load_json(path):

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -91,7 +91,7 @@ class TestBackoff(_bases.TestBase):
         _logger.warning(
             "Running full backoff test, which shouldn't usually be done.")
 
-    def tearDown(self):  # FIXME: Do this with addCleanup from setUp instead.
+    def tearDown(self):
         """Restore the stack size."""
         threading.stack_size(self._old_stack_size)
         super().tearDown()

--- a/tests/test_cached_embeddings.py
+++ b/tests/test_cached_embeddings.py
@@ -7,9 +7,10 @@ Those embedding functions are the versions that cache to disk. They are
 otherwise like the same-named functions residing directly in ``embed``.
 """
 
-import pathlib
+from pathlib import Path
 import shutil
 import unittest
+from unittest.mock import patch
 
 from embed import cached
 from tests import _bases
@@ -22,12 +23,9 @@ class _TestDiskCacheEmbeddingsBase(_bases.TestDiskCachedBase):
         """Patch ``DEFAULT_DATA_DIR`` to the temporary directory."""
         super().setUp()
 
-        self._old_data_dir = cached.DEFAULT_DATA_DIR
-        cached.DEFAULT_DATA_DIR = self._dir_path
-
-    def tearDown(self):  # FIXME: Do this with addCleanup in setUp instead.
-        cached.DEFAULT_DATA_DIR = self._old_data_dir
-        super().tearDown()
+        self.enterContext(
+            patch(f'{cached.__name__}.DEFAULT_DATA_DIR', self._dir_path),
+        )
 
 
 class _TestDiskCacheHitBase(_TestDiskCacheEmbeddingsBase):
@@ -37,7 +35,7 @@ class _TestDiskCacheHitBase(_TestDiskCacheEmbeddingsBase):
         """Copy embeddings to the temporary directory."""
         super().setUp()
 
-        for path in pathlib.Path('tests_data').glob('*.json'):
+        for path in Path('tests_data').glob('*.json'):
             shutil.copy(path, self._dir_path)
 
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -26,7 +26,7 @@ class TestApiKey(_bases.TestBase):
         openai.api_key = 'sk-fake-redact-outer'
         embed.api_key = 'sk-fake-redact-inner'
 
-    def tearDown(self):  # FIXME: Do this with addCleanup from setUp instead.
+    def tearDown(self):
         """Unpatch api_key attributes."""
         embed.api_key = self._real_key_embed
         openai.api_Key = self._real_key_openai


### PR DESCRIPTION
**This is a request to merge commits into the [`tests`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/tests) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

Python 3.11 has `unittest.TestCase.enterContext`. This uses that on 3.11, and defines and uses a simplified `enterContext` sufficient for our purposes when the Python version is less than 3.11.

This also removes some FIXMEs about eliminating tearDown in a couple leaf classes where there is no disadvantage of using it (and where the needed logic is not naturally expressed with `enterContext` or `addCleanup`).

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/tests-cm) for unit test status.