### PR TITLE
Update "What's here"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,15 @@ OpenAI’s servers.
 
 ### Major Modules (Tests)
 
-<!-- FIXME: Update this again when all new test modules have been created. -->
+[`test_embed`](tests/test_embed.py) tests the functions directly in `embed`.
+This includes testing that similarities are within expected ranges.
 
-[`test_embed`](tests/test_embed.py) has automated tests of the functions in
-`embed`. This includes testing that some examples’ similarities are within
-expected ranges.
+[`test_cached_embeddings`](tests/test_cached_embeddings.py) tests those same
+general behaviors for the functions in `embed.cached` that cache results to
+disk.
 
-[`test_cached_caching`](tests/test_cached_caching.py) has automated tests
-*specific* to functionality in `embed.cached`.
+[`test_cached_caching`](tests/test_cached_caching.py) also tests the function
+in `embed.cached`, but tests the on-disk caching functionality itself.
 
 ### Notebooks
 
@@ -66,6 +67,9 @@ usage and experiments, calling functions in the `embed` module.
 
 [`structure.ipynb`](notebooks/structure.ipynb) examines the JSON responses
 returned by the OpenAI embeddings API endpoint.
+
+[`cached.ipynb`](notebooks/cached.ipynb) shows examples of on-disk caching and
+generates some test data used in `test_cached_embeddings`.
 
 ## Setup
 


### PR DESCRIPTION
**This is a request to merge commits into the [`tests`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/tests) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

In the readme, this brings the "What's here" section up to date on the notebooks, and on what I think are the most useful modules to know about when *starting* to read the code.

In the test suite, some "private" modules might be considered more important than those listed. But I haven't listed them, at least for now. This is not because there's any reason readers shouldn't be interested in them. Rather, they can be discovered by following references upward from the listed modules. More importantly, I don't want this section of the readme to become excessively long, which would decrease its value and also make it more prone to falling out of date.