### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.11', '3.10', '3.9', '3.8', '3.7']
+        python-version: ['3.11', '3.10', '3.9', '3.8']
 
     runs-on: ${{ matrix.os }}
 

--- a/tests/_audit.py
+++ b/tests/_audit.py
@@ -1,10 +1,9 @@
 """Capturing ``open`` audit events for tests. This uses at most one hook."""
 
-__all__ = ['listening_for_open', 'skip_if_unavailable']
+__all__ = ['listening_for_open']
 
 import contextlib
 import sys
-import unittest
 
 _hooked = False  # pylint: disable=invalid-name  # Not a constant.
 """Whether the audit hook has been installed."""
@@ -41,10 +40,3 @@ def listening_for_open(listener):
         yield listener
     finally:
         _listener = None
-
-
-skip_if_unavailable = unittest.skipIf(
-    sys.version_info < (3, 8),
-    'sys.addaudithook introduced in Python 3.8',
-)
-"""Skip a ``unittest`` test if audit event functionality is unavailable."""

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -55,11 +55,8 @@ _is_backoff_message = re.compile(
 def _run_batch(batch_index):
     """Run a batch of ``_BATCH_SIZE`` sequential jobs in the backoff test."""
     for job_index in range(_BATCH_SIZE):
-        # Note: We support Python 3.7, so we can't write {batch_index=}.
-        embed.embed_one_req(
-            'Testing rate limiting. '
-            f'batch_index={batch_index} job_index={job_index}',
-        )
+        text = f'Testing rate limiting. {batch_index=} {job_index=}'
+        embed.embed_one_req(text)
 
 
 @unittest.skipUnless(

--- a/tests/test_cached_caching.py
+++ b/tests/test_cached_caching.py
@@ -109,7 +109,6 @@ class _TestDiskCachedCachingBase(_bases.TestDiskCachedBase):
 
                 self.assertEqual(log_context.output, [expected_message])
 
-    @_audit.skip_if_unavailable
     def test_load_confirmed_by_audit_event(self):
         self._write_fake_data_file()
 
@@ -118,7 +117,6 @@ class _TestDiskCachedCachingBase(_bases.TestDiskCachedBase):
 
         listener.assert_any_call(str(self._path), 'r', ANY)
 
-    @_audit.skip_if_unavailable
     def test_save_confirmed_by_audit_event(self):
         with _audit.listening_for_open(Mock()) as listener:
             self.func(self.text_or_texts, data_dir=self._dir_path)


### PR DESCRIPTION
It doesn't support the latest numpy, keeping support for it is already complicating our tests somewhat, and keeping it would even further complicate dependency specification when we put our dependencies in `pyproject.toml` and use poetry to manage them.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/no37) for unit test status.