### PR TITLE
Automatically check Python version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,10 @@ jobs:
     permissions:
       contents: write
 
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
@@ -54,13 +58,17 @@ jobs:
       - name: Install poetry
         run: pipx install poetry
 
-      # FIXME: Make sure we are using the correct version of Python.
-
       - name: Install the environment
         run: poetry install --only=main,dev
 
       - name: Print Python version
         run: poetry run python -V
+
+      - name: Validate Python version
+        run: |
+          poetry run python -c \
+              'import sys; assert sys.version.startswith(f"{sys.argv[1]}.")' \
+              ${{ matrix.python-version }}
 
       - name: Set up mutex
         if: needs.read-blocking-config.outputs.use-mutex != 'false'
@@ -110,6 +118,12 @@ jobs:
       - name: Print Python version
         run: python -V
 
+      - name: Validate Python version
+        run: |
+          python -c \
+              'import sys; assert sys.version.startswith(f"{sys.argv[1]}.")' \
+              ${{ matrix.python-version }}
+
       - name: Set up mutex
         if: needs.read-blocking-config.outputs.use-mutex != 'false'
         uses: EliahKagan/actions-mutex@v2
@@ -144,6 +158,12 @@ jobs:
 
       - name: Make editable install
         run: pip install -e .
+
+      - name: Print Python version
+        run: python -V
+
+      - name: Validate Python version
+        run: python -c 'import sys; assert sys.version_info[:2] == (3, 11)'
 
       - name: Set up mutex
         if: needs.read-blocking-config.outputs.use-mutex != 'false'


### PR DESCRIPTION
**This is a request to merge commits into the [`poetry-ci`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/poetry-ci) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

This adds steps to CI test jobs to validate the expected Python version and fail the job if it is incorrect.

This causes the new poetry-based test jobs that had wrongly passed before to fail, as they should. This also adds analogous checks to the conda-based test jobs, which continue to pass.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/poetry-ci-next) for unit test status.