### PR TITLE
Use symbolic names in markdownlint suppressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 <!-- SPDX-License-Identifier: 0BSD -->
 
-<!-- Logo. Tell markdownlint it's OK this precedes <h1> and has long lines. -->
 <!-- markdownlint-capture -->
-<!-- markdownlint-disable MD041 MD013 -->
+<!-- markdownlint-disable first-line-h1 line-length -->
 <img src="doc/logo.svg"
      alt="Drawing of text-embedding-ada-002 embedding vectors for two sentences – “El gato corre.” and “The cat runs.” – and the 22.7° angle between them"
      title="Drawing of text-embedding-ada-002 embedding vectors for two sentences – “El gato corre.” and “The cat runs.” – and the 22.7° angle between them"


### PR DESCRIPTION
Instead of warning numbers.

This makes clearer what is happening, and also avoids the need to repeat the information about what's being suppressed in a separate comment (that could fall out of date).