### PR TITLE
Migrate to setup-micromamba

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,8 +48,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Provision with micromamba
-      uses: mamba-org/provision-with-micromamba@v16
+    - name: Set up micromamba
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: environment.yml
 
     - name: Make editable install
       run: pip install -e .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,8 +39,10 @@ jobs:
       - name: Install pylint-sarif (unofficial fork)
         run: pipx install pylint-sarif-unofficial
 
-      - name: Install Conda environment from environment.yml
-        uses: mamba-org/provision-with-micromamba@v16
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: environment.yml
 
       - name: Make editable install
         run: pip install -e .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,8 +109,10 @@ jobs:
           perl -i -spwe 's/^ *- python=\K.+$/$pyver/' -- \
               -pyver=${{ matrix.python-version }} environment.yml
 
-      - name: Install Conda environment from environment.yml
-        uses: mamba-org/provision-with-micromamba@v16
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: environment.yml
 
       - name: Make editable install
         run: pip install -e .
@@ -153,8 +155,10 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v3
 
-      - name: Install Conda environment from environment.yml
-        uses: mamba-org/provision-with-micromamba@v16
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: environment.yml
 
       - name: Make editable install
         run: pip install -e .


### PR DESCRIPTION
We should switch from the `provision-with-micromamba` action to the `setup-micromamba` action, because `provision-with-micromamba` is now deprecated. It is no longer maintained, and its developers officially recommend migration to `setup-micromamba`:

- https://github.com/mamba-org/provision-with-micromamba/releases/tag/v16
- https://github.com/mamba-org/provision-with-micromamba#migration-to-setup-micromamba
- https://github.com/mamba-org/setup-micromamba

#124 updates `provision-with-micromamba` to its final version. The only change in that update is the deprecation--the action now emits annotations to remind us to stop using it and to migrate to `setup-micromamba` instead. Either of the two approaches to coordinating this PR and #124 is fine:

- If #124 is accepted, I can easily rebase this PR to fix the conflict (or you can fix the conflict when merging). This has the advantage that, if this PR is merged but later reverted, the restored `provision-with-micromamba` would emit warning annotations about being deprecated and unmaintained.
- Merging this PR without having merged #124 would also be fine, and in that case Dependabot should automatically close #124 due to the dependency being removed. This has the advantage of being faster and simpler, and producing fewer commits peripheral to the core purpose of this repository.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/micromamba) for unit test status, to verify that the new action is working properly.