### PR TITLE
Move run-test-scripts to the workflow directory

### DIFF
--- a/.github/workflows/run-test-scripts
+++ b/.github/workflows/run-test-scripts
@@ -1,5 +1,5 @@
 #!/bin/sh
-# This runs test modules as scripts, mainly for CI. Run it from the repo root.
+# A CI job runs this from the repo root. It runs each test module as a script.
 
 set -eux
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,7 +170,7 @@ jobs:
         uses: EliahKagan/actions-mutex@v2
 
       - name: Run test modules as scripts
-        run: meta/run-test-scripts
+        run: .github/workflows/run-test-scripts
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           TESTS_CACHE_EMBEDDING_CALLS_IN_MEMORY: 'no'


### PR DESCRIPTION
Since it is in practice only ever used on CI, and since the meta directory -- which it was the only remaining file in -- doesn't really have a clear meaning or purpose in this repository.