### PR TITLE
Clarify TODO about poetry installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install poetry
-        run: pip install poetry  # Explore other approaches.
+        run: pip install poetry  # TODO: Explore other approaches.
 
       - name: Install the environment
         run: poetry install --only=main,dev


### PR DESCRIPTION
Without something like "TODO" or "FIXME", this looked like it may have been documenting the effect or ultimate goal of installing poetry on CI, rather than our interest in changing how we do so.

This only changes a comment, but unit test status can be seen on [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/pipx).