### PR TITLE
Get Dependabot version updates for Python monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: pip
     directory: '/'
     schedule:
-      interval: daily
+      interval: monthly
     allow:
       - dependency-type: all
     open-pull-requests-limit: 100


### PR DESCRIPTION
Now that Dependabot version updates have been enabled for this project for a while and we've gotten a sense of how they work into our workflow, I suggest that we get Dependabot version updates for Python dependencies much less frequently: monthly instead of daily.

We can still run `poetry up --latest` during development, and we may even wish to do so more often than we currently do. If we don't run it for a while--which might happen if nearly all work is concentrated on a complex feature branch on which there are no dependency changes, or if the project goes through a lull during which no work is done--then we'll still get Dependabot pull requests for them within a month, which can then either be merged individually or triggered to auto-close by a manual update.

**This does not affect Dependabot *security* updates.** Dependabot will continue to open pull requests for updates that patch CVEs as soon as such new versions become available (or, if the CVE comes after the update, then at that time), including for Python dependencies.

This also doesn't affect Dependabot version updates for GitHub Actions dependencies, which I've kept as daily. (Those are updated less often, so it's less noisy, and we may as well be informed of updates to them as soon as they become available.)

If you want to see it, the `dependabot.yml` [syntax check](https://github.com/EliahKagan/EmbeddingScratchwork/runs/13872138366) completed successfully [on my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/deps).