### PR TITLE
Don't trigger pylint "Too many ancestors" until 8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,4 @@ generated-members = "orjson.*"
 load-plugins = [
     "pylint_actions",
 ]
+max-parents = 8


### PR DESCRIPTION
Instead of 7.

A number of our test classes have 8 ancestors. The number that do increased recently, as a result of the new test classes to test caching embeddings to disk as safetensors files. But the process of extending the tests (in #137) didn't seem cumbersome or otherwise negatively affected by having that many ancestors. Since I think it is not causing a problem in this project, I think it is reasonable to increase the limit at which pylint warns from 7 to 8.