### PR TITLE
Fix instructions to regenerate test data

### DIFF
--- a/notebooks/cached.ipynb
+++ b/notebooks/cached.ipynb
@@ -417,7 +417,8 @@
    "source": [
     "## Generating data for tests\n",
     "\n",
-    "To regenerate this test data, delete the `.json` files in `tests_data/` and re-run the notebook."
+    "To regenerate this test data, delete the `.json` and `.safetensors` files in\n",
+    "`tests_data/` and re-run the notebook."
    ]
   },
   {


### PR DESCRIPTION
I had forgotten to change it from saying to delete `.json` files to saying to delete both `.json` and `.safetensors` files. (The data were generated correctly, just this small omission in the documentation needs correcting.)