### PR TITLE
Make JupyterLab major version clear for conda

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,6 +35,7 @@
         "ipykernel",
         "ipynb",
         "jupyter",
+        "jupyterlab",
         "Kagan",
         "lionsleep",
         "lukewiwa",

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   # For notebooks
   - graphviz
   - ipykernel
-  - jupyterlab
+  - jupyterlab>=4
   - jupyter-collaboration
   - python-graphviz
   - tabulate


### PR DESCRIPTION
We're not specifying versions for most packages in environment.yml (unlike pyproject.toml/poetry.lock), but in the case of JupyterLab, the jupyter-collaboration dependency, which is also listed, only makes sense when the jupyterlab package is >=4.

This also adds a missing spelling word.

The likelihood of breakage is extremely low, but see [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/nb) to verify that the change in dependency specification didn't break unit tests.