### PR TITLE
Fix JupyterLab CORS in codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,5 +28,5 @@
             }
         }
     },
-    "onCreateCommand": ".devcontainer/onCreate"
+    "onCreateCommand": [".devcontainer/onCreate"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,5 +28,6 @@
             }
         }
     },
-    "onCreateCommand": [".devcontainer/onCreate"]
+    "onCreateCommand": [".devcontainer/onCreate"],
+    "postStartCommand": [".devcontainer/postStart"]
 }

--- a/.devcontainer/postStart
+++ b/.devcontainer/postStart
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2023 Eliah Kagan
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+# REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+# AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+# INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+# LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+# OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+# PERFORMANCE OF THIS SOFTWARE.
+
+set -e
+
+# The pathname to the GitHub Codespaces metadata directory.
+readonly cs_meta_path='/workspaces/.codespaces'
+
+# The pathname to the JSON file listing GitHub Codespace environment variables.
+readonly cs_vars_path="$cs_meta_path/shared/environment-variables.json"
+
+# The pathname to the JupyterLab configuration file.
+readonly config_path=~/.jupyter/jupyter_lab_config.py
+
+# Python code comment we append to indicate we automatically generated a line.
+readonly auto_comment='# postStart generated'
+
+# Python regex for the end of a permitted URL, when the beginning is also okay.
+readonly url_end_pattern='-[89][0-9]{3}\.preview\.app\.github\.dev'
+
+in_codespace() {
+    # TODO: Find a more reliable way to check if we are running in a codespace.
+    test -e "$cs_meta_path"
+}
+
+have_manual_conf() {
+    local auto_pattern # POSIX ERE that will match a line that is safe to lose.
+    printf -v auto_pattern '(^|%s)[[:blank:]]*$' "$auto_comment"
+    test -e "$config_path" && grep -Eqv "$auto_pattern" -- "$config_path"
+}
+
+new_empty_conf() {
+    mkdir -p -- "$(dirname -- "$config_path")"
+    : >"$config_path"
+}
+
+append_to_conf() {
+    printf '%s  %s\n' "$1" "$auto_comment" >>"$config_path"
+}
+
+generate_conf() {
+    local codespace_name url_pattern
+
+    codespace_name="$(jq -r .CODESPACE_NAME -- "$cs_vars_path")"
+    url_pattern="https://${codespace_name}${url_end_pattern}"
+
+    new_empty_conf
+    append_to_conf 'c = get_config()  # noqa'
+    append_to_conf "c.ServerApp.allow_origin_pat = r'$url_pattern'"
+}
+
+if in_codespace && ! have_manual_conf; then
+    generate_conf
+fi


### PR DESCRIPTION
Closes #148

This matches on the domain name generated from the specific codespace name, which is determined in a postStart script.

The script is copied from palgoviz. Currently it is the code shown here:

https://github.com/EliahKagan/palgoviz/blob/main/.devcontainer/postStart

I believe what I wrote that will work just as well here.

This doesn't fix the similar but separate CORS problem with nbdiff-web in codespaces. (While they are often used together, jupyterlab and nbdime are separate.)

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/cors) for unit test status, though none of those tests should actually be affected by this.