### PR TITLE
Make regex matching logic more idiomatic

### DIFF
--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -18,14 +18,14 @@ import attrs
 
 import embed
 
+_TRUTHY_REGEX = re.compile(r'true|yes|1', re.IGNORECASE)
+"""Regex to match a configuration string considered to mean ``True``."""
+
+_FALSY_REGEX = re.compile(r'(?:false|no|0)?', re.IGNORECASE)
+"""Regex to match a configuration string conisdered to mean ``False``."""
+
 _logger = logging.getLogger(__name__)
 """Logger for messages from this test helper module."""
-
-_truthy_config = re.compile(r'true|yes|1', re.IGNORECASE).fullmatch
-"""Check if a configuration string should be considered to mean ``True``."""
-
-_falsy_config = re.compile(r'(?:false|no|0)?', re.IGNORECASE).fullmatch
-"""Check if a configuration string should be considered to mean ``False``."""
 
 
 def getenv_bool(name):
@@ -39,9 +39,9 @@ def getenv_bool(name):
     - Otherwise, the value is ill-formed, and ``RuntimeError`` is raised.
     """
     value = os.environ.get(name, default='')
-    if _truthy_config(value):
+    if _TRUTHY_REGEX.fullmatch(value):
         return True
-    if _falsy_config(value):
+    if _FALSY_REGEX.fullmatch(value):
         return False
     raise RuntimeError(
         f"Can't parse environment variable as boolean: {name}={value!r}")

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -42,14 +42,14 @@ _BATCH_COUNT = 600
 _BATCH_SIZE = 8
 """Number of requests each batch makes sequentially in the backoff test."""
 
-_logger = logging.getLogger(__name__)
-"""Logger for messages from this test module."""
-
-_is_backoff_message = re.compile(
+_BACKOFF_MESSAGE_REGEX = re.compile(
     r'INFO:backoff:Backing off _post_request\(\.\.\.\) for [0-9.]+s '
     r'\(<Response \[429\]>\)',
-).fullmatch
-"""Check if the string is a log message about backoff with expected details."""
+)
+"""Regex to match a log message aobut backoff with expected details."""
+
+_logger = logging.getLogger(__name__)
+"""Logger for messages from this test module."""
 
 
 def _run_batch(batch_index):
@@ -105,7 +105,7 @@ class TestBackoff(_bases.TestBase):
                 )
 
         got_backoff = any(
-            _is_backoff_message(message)
+            _BACKOFF_MESSAGE_REGEX.fullmatch(message)
             for message in log_context.output
         )
         self.assertTrue(got_backoff)


### PR DESCRIPTION
Although the previous way has the advantage of making clear that the regular expressions are used for full matches, it is somewhat unidiomatic. I like that style, but I think assigning the results of `re.compile` to constants and calling `fullmatch` at the use sites will be easier to understand, for people unfamiliar with the code, than "precomputing" their bound `fullmatch` methods and assigning those as helpers.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/regular) for unit test status.