### PR TITLE
Make TestDiskCachedBase._dir_path public

### DIFF
--- a/tests/_bases.py
+++ b/tests/_bases.py
@@ -71,7 +71,7 @@ class TestDiskCachedBase(TestEmbedBase):
         super().setUp()
 
         # pylint: disable=consider-using-with  # enterContext is like "with".
-        self._dir_path = Path(self.enterContext(TemporaryDirectory()))
+        self.dir_path = Path(self.enterContext(TemporaryDirectory()))
 
     @property
     @abstractmethod

--- a/tests/test_cached_caching.py
+++ b/tests/test_cached_caching.py
@@ -143,7 +143,7 @@ class _TestDiskCachedCachingBase(_bases.TestDiskCachedBase):
             path=self._path,
         )
 
-        with patch(f'{cached.__name__}.DEFAULT_DATA_DIR', self._dir_path):
+        with patch(f'{cached.__name__}.DEFAULT_DATA_DIR', self.dir_path):
             with self.assertLogs(logger=cached.__name__) as log_context:
                 self.func(self.text_or_texts, file_type=self.file_type)
 
@@ -160,7 +160,7 @@ class _TestDiskCachedCachingBase(_bases.TestDiskCachedBase):
 
         with patch(f'{cached.__name__}.DEFAULT_FILE_TYPE', self.file_type):
             with self.assertLogs(logger=cached.__name__) as log_context:
-                self.func(self.text_or_texts, data_dir=self._dir_path)
+                self.func(self.text_or_texts, data_dir=self.dir_path)
 
         self.assertEqual(
             log_context.output, [expected_message],
@@ -175,7 +175,7 @@ class _TestDiskCachedCachingBase(_bases.TestDiskCachedBase):
     @property
     def _path(self):
         """Path of temporary test file."""
-        return self._dir_path / f'{self.basename}.{self.file_type}'
+        return self.dir_path / f'{self.basename}.{self.file_type}'
 
     def _call_caching_embedder(self, *, func=None):
         """Call a caching embedder. Pass usual per-subclass test arguments."""
@@ -184,7 +184,7 @@ class _TestDiskCachedCachingBase(_bases.TestDiskCachedBase):
 
         return func(
             self.text_or_texts,
-            data_dir=self._dir_path,
+            data_dir=self.dir_path,
             file_type=self.file_type,
         )
 

--- a/tests/test_cached_embeddings.py
+++ b/tests/test_cached_embeddings.py
@@ -22,7 +22,7 @@ class _TestDiskCacheEmbeddingsBase(_bases.TestDiskCachedBase):
     def setUp(self):
         """Patch ``DEFAULT_DATA_DIR`` and ``DEFAULT_FILE_TYPE``."""
         super().setUp()
-        self._patch('DEFAULT_DATA_DIR', self._dir_path)
+        self._patch('DEFAULT_DATA_DIR', self.dir_path)
         self._patch('DEFAULT_FILE_TYPE', self.file_type)
 
     def _patch(self, attribute_name, new_value):
@@ -40,7 +40,7 @@ class _TestDiskCacheHitBase(_TestDiskCacheEmbeddingsBase):
 
         for file_type in 'json', 'safetensors':
             for path in Path('tests_data').glob(f'*.{file_type}'):
-                shutil.copy(path, self._dir_path)
+                shutil.copy(path, self.dir_path)
 
 
 class TestDiskCacheHitEmbedOneJson(


### PR DESCRIPTION
Closes #153

This renames it to be public, from `_dir_path` to `dir_path`.

It is accessed, and needs to be accessed, in derived classes. So it should be public or protected. I don't think the additional complexity of it being protected, even just documenting it as such, is justified here. Making it public also is more consistent with other design choices where members the test bases provide to their derived classes are public in our test suite.

See #153, which this fixes, for details.

(Note that this is still a member of a class that is contained in a nonpublic module, `_bases`.)

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/dir) for unit test status.