### PR TITLE
Set up isort

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   flake8:
     runs-on: ubuntu-latest
+
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
@@ -52,3 +53,25 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: pylint.sarif
+
+  isort:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
+
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: environment.yml
+
+      - name: Make editable install
+        run: pip install -e .
+
+      - name: isort Check
+        uses: isort/isort-action@v1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,6 +35,7 @@
         "graphvizonline",
         "ipykernel",
         "ipynb",
+        "isort",
         "jupyter",
         "jupyterlab",
         "Kagan",

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   # For development
   - attrs
   - flake8
+  - isort
   - parameterized
   - pylint
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3911,4 +3911,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "00318a6a7aadb02a46a53c72bf7d9faff785f1ca60aea4847467f427d732bd41"
+content-hash = "bbff72651ce196a651c2debe4077dd281379d5c33b19c3eb61cc8da94cbbd34b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ safetensors = "^0.3.1"
 [tool.poetry.group.dev.dependencies]
 attrs = "^23.1.0"
 flake8 = { version = "^6.0.0", python = ">=3.8.1,<4.0" }
+isort = "^5.12.0"
 parameterized = "^0.9.0"
 pylint = "^2.17.4"
 pylint-actions = "^0.4.0"
@@ -44,6 +45,12 @@ tabulate = "^0.9.0"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.isort]
+atomic = true
+force_sort_within_sections = true
+include_trailing_comma = true
+multi_line_output = 3
 
 [tool.pylint.main]
 disable = [

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -30,8 +30,8 @@ import unittest
 
 import backoff
 
-from tests import _bases, _helpers
 import embed
+from tests import _bases, _helpers
 
 _STACK_SIZE = 32_768
 """Stack size in bytes for newly created worker threads. Do not change this."""

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -20,7 +20,6 @@ import embed
 from embed._keys import _get_key_if_available
 from tests import _bases
 
-
 if sys.version_info < (3, 11):
     @contextlib.contextmanager
     def _chdir(path):


### PR DESCRIPTION
For manual/local use to sort imports, and on CI to lint import style (added to the Python link workflow).

This was already present as an indirect dependency, but now it's a direct dependency in the `dev` group and it's configured in `pyproject.toml`.

Because it was already present as an indirect dependency, this change shouldn't be able to cause a test failure, but unit test status can be seen on [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/isort).