### PR TITLE
Put more metadata in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,21 @@ authors = [
 ]
 license = "0BSD"
 readme = "README.md"
+homepage = "https://github.com/dmvassallo/EmbeddingScratchwork"
+repository = "https://github.com/dmvassallo/EmbeddingScratchwork"
+keywords = [
+    "embeddings",
+    "similarity",
+    "vector search",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Text Processing",
+]
 packages = [
     { include = "embed" },
 ]


### PR DESCRIPTION
For when we eventually publish to PyPI.

Of course, since we are going to rename the project sometime between now and when we publish to PyPI, we'll have to change the metadata that reflect the name. But I think it's still easier to have most or all of the fields beforehand; the name can be changed with a supervised search and replace when it's time to do so.

Unit test status can be seen on [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/meta), though this change definitely shouldn't be able to break any of the tests.