### PR TITLE
Explicitly don't track .tox directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@ __pycache__/
 .ipynb_checkpoints/
 .jupyter_ystore.db
 
+# Local tox files
+.tox/
+
 # OpenAI API key
 .api_key


### PR DESCRIPTION
Although tox creates the `.tox/` directory with a `.gitignore` file inside that ignores the entire directory, this may be absent for brief periods of time in some situations, such as when deleting the entire directory (because `.tox/.gitignore` is often deleted before other files and directories inside `.tox/` are deleted). This can cause slowdown in editors or, more likely, editors to issue warnings about how not all changes can be reflected in the editor due to the large frequency at which they are happening.

Explicitly `.gitignore`ing `.tox/` fixes that.

[My branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/tox) shows unit test status, though this change is irrelevant to that.