### PR TITLE
Give explicit Python versions for flake8-pyproject

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3911,4 +3911,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "be5125ef79327cd11e318486113bd6e021c6157f612dbbee14030dab513498a7"
+content-hash = "06b4631dac753c3f59c0d032cfe22c98e86608fbaf1690582b18ab74779f8b57"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ safetensors = "^0.3.1"
 [tool.poetry.group.dev.dependencies]
 attrs = "^23.1.0"
 flake8 = { version = "^6.0.0", python = ">=3.8.1,<4.0" }
-flake8-pyproject = "^1.2.3"
+flake8-pyproject = { version = "^1.2.3", python = ">=3.8.1,<4.0" }
 isort = "^5.12.0"
 parameterized = "^0.9.0"
 pylint = "^2.17.4"


### PR DESCRIPTION
Closes #168

Specifying the Python versions for `flake8-pyproject` as the same range as for `flake8` itself (which is just the range of versions `flake8` actually supports) fixes #168. Without this, calculating dependencies usually works, but calculating or expressing them fails at least in the situation of `poetry export --only-dev` (which should be able to work, CI might use it in the future, and our `tox` configuration uses it currently).

This time, I have checked that the problem documented in #168 has gone away, both on GNU/Linux and Windows, and both for a direct run of `poetry export --only-dev` and for `tox`, including that it does not happen in the `tox` step where it did before and that this step succeeds. I have also tested that `flake8` continues to work correctly when run directly in the project directory from a `poetry`-managed virtual environment located in a local `.venv` directory, including that `flake8` does not traverse into that directory.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/flake8) for unit test status, though this should not be able to affect that.