### PR TITLE
Add pytest runner and use it via tox

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - isort
   - parameterized
   - pylint
+  - pytest
 
   # For notebooks
   - graphviz

--- a/poetry.lock
+++ b/poetry.lock
@@ -1183,6 +1183,17 @@ files = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+
+[[package]]
 name = "ipykernel"
 version = "6.23.2"
 description = "IPython Kernel for Jupyter"
@@ -2612,6 +2623,21 @@ packaging = "*"
 tenacity = ">=6.2.0"
 
 [[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
 name = "prometheus-client"
 version = "0.17.0"
 description = "Python client for the Prometheus monitoring system."
@@ -2851,6 +2877,28 @@ files = [
     {file = "pyrsistent-0.19.3-py3-none-any.whl", hash = "sha256:ccf0d6bd208f8111179f0c26fdf84ed7c3891982f2edaeae7422575f47e66b64"},
     {file = "pyrsistent-0.19.3.tar.gz", hash = "sha256:1a2994773706bbb4995c31a97bc94f1418314923bd1048c6d964837040376440"},
 ]
+
+[[package]]
+name = "pytest"
+version = "7.3.2"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-7.3.2-py3-none-any.whl", hash = "sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295"},
+    {file = "pytest-7.3.2.tar.gz", hash = "sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -3911,4 +3959,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "06b4631dac753c3f59c0d032cfe22c98e86608fbaf1690582b18ab74779f8b57"
+content-hash = "89ea9c033ee89e4d568ad0c278400805d3e3b919021a8195309079a161e47a57"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ pylint = "^2.17.4"
 pylint-actions = "^0.4.0"
 pylint-exit = "^1.2.0"
 pylint-sarif-unofficial = "^0.1.0"
+pytest = "^7.3.2"
 subaudit = "^0.1.0"
 
 [tool.poetry.group.notebook.dependencies]
@@ -101,7 +102,7 @@ legacy_tox_ini = """
         poetry export --only=dev --output={env_tmp_dir}/requirements_dev.txt
         pip install -qr {env_tmp_dir}/requirements_dev.txt
     commands =
-        python -m unittest
+        pytest --color=yes
     setenv =
         TESTS_CACHE_EMBEDDING_CALLS_IN_MEMORY = yes
 


### PR DESCRIPTION
This adds `pytest` as a developement dependency, but only for the purpose of using it as a test runner for our `unittest` tests. All the automated tests in the project remain `unittest` and there are currently no plans to change that, but it is sometimes convenient to use `pytest` as the test runner, because of the way in which it shows output.

One situation where this is likely to benefit is when running tests with `tox`, and this also changes the `tox` configuration to run the `unittest` tests with `pytest` instead of the `unittest` runner itself.

No CI jobs use `pytest`, and there is currently no plan to change that.

[My branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/runner) has unit test status, though this change should not be able to fix that, since CI is still not using `pytest` (nor is that planned).