### PR TITLE
Split "dev" dependency group into "test" and "lint"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
         run: pip install poetry  # TODO: Explore other approaches.
 
       - name: Install the environment
-        run: poetry install --only=main,dev
+        run: poetry install --only=main,test
 
       - name: Print Python version
         run: poetry run python -V

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,6 +57,7 @@
         "pylint",
         "pyproject",
         "pyreverse",
+        "pytest",
         "pyver",
         "repr",
         "safetensors",

--- a/environment.yml
+++ b/environment.yml
@@ -13,14 +13,16 @@ dependencies:
   - requests
   - safetensors
 
-  # For development
+  # For testing
   - attrs
+  - parameterized
+  - pytest
+
+  # For linting
   - flake8
   - flake8-pyproject
   - isort
-  - parameterized
   - pylint
-  - pytest
 
   # For notebooks
   - graphviz

--- a/poetry.lock
+++ b/poetry.lock
@@ -3959,4 +3959,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "89ea9c033ee89e4d568ad0c278400805d3e3b919021a8195309079a161e47a57"
+content-hash = "c934bdd404b8d229b27ccdf79eb1b05c700731f59dd6e6c800e251c090d178a2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,18 +38,20 @@ orjson = "^3.9.1"
 requests = "^2.31.0"
 safetensors = "^0.3.1"
 
-[tool.poetry.group.dev.dependencies]
+[tool.poetry.group.test.dependencies]
 attrs = "^23.1.0"
+parameterized = "^0.9.0"
+pytest = "^7.3.2"
+subaudit = "^0.1.0"
+
+[tool.poetry.group.lint.dependencies]
 flake8 = { version = "^6.0.0", python = ">=3.8.1,<4.0" }
 flake8-pyproject = { version = "^1.2.3", python = ">=3.8.1,<4.0" }
 isort = "^5.12.0"
-parameterized = "^0.9.0"
 pylint = "^2.17.4"
 pylint-actions = "^0.4.0"
 pylint-exit = "^1.2.0"
 pylint-sarif-unofficial = "^0.1.0"
-pytest = "^7.3.2"
-subaudit = "^0.1.0"
 
 [tool.poetry.group.notebook.dependencies]
 graphviz = "^0.20.1"
@@ -99,8 +101,8 @@ legacy_tox_ini = """
     package = wheel
     allowlist_externals = poetry
     commands_pre =
-        poetry export --only=dev --output={env_tmp_dir}/requirements_dev.txt
-        pip install -qr {env_tmp_dir}/requirements_dev.txt
+        poetry export --only=test --output={env_tmp_dir}/requirements_test.txt
+        pip install -qr {env_tmp_dir}/requirements_test.txt
     commands =
         pytest --color=yes
     setenv =
@@ -109,12 +111,18 @@ legacy_tox_ini = """
     [testenv:flake8]
     description = flake8 lint
     basepython = py311
+    commands_pre =
+        poetry export --only=lint --output={env_tmp_dir}/requirements_lint.txt
+        pip install -qr {env_tmp_dir}/requirements_lint.txt
     commands =
         flake8
 
     [testenv:isort]
     description = isort check
     basepython = py311
+    commands_pre =
+        poetry export --only=lint --output={env_tmp_dir}/requirements_lint.txt
+        pip install -qr {env_tmp_dir}/requirements_lint.txt
     commands =
         isort --check .
 """


### PR DESCRIPTION
The amount of stuff in the `dev` group was growing, so I split it, which should make the CI test jobs, as well as `tox`, faster.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/groups) for unit test status. This change definitely has the potential, if incorrect, to break tests.