### PR TITLE
Add pytest-sugar plugin

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - attrs
   - parameterized
   - pytest
+  - pytest-sugar
 
   # For linting
   - flake8

--- a/poetry.lock
+++ b/poetry.lock
@@ -2935,6 +2935,25 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-sugar"
+version = "0.9.7"
+description = "pytest-sugar is a plugin for pytest that changes the default look and feel of pytest (e.g. progressbar, show tests that fail instantly)."
+optional = false
+python-versions = "*"
+files = [
+    {file = "pytest-sugar-0.9.7.tar.gz", hash = "sha256:f1e74c1abfa55f7241cf7088032b6e378566f16b938f3f08905e2cf4494edd46"},
+    {file = "pytest_sugar-0.9.7-py2.py3-none-any.whl", hash = "sha256:8cb5a4e5f8bbcd834622b0235db9e50432f4cbd71fef55b467fe44e43701e062"},
+]
+
+[package.dependencies]
+packaging = ">=21.3"
+pytest = ">=6.2.0"
+termcolor = ">=2.1.0"
+
+[package.extras]
+dev = ["black", "flake8", "pre-commit"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -3468,6 +3487,20 @@ files = [
 doc = ["reno", "sphinx", "tornado (>=4.5)"]
 
 [[package]]
+name = "termcolor"
+version = "2.3.0"
+description = "ANSI color formatting for output in terminal"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "termcolor-2.3.0-py3-none-any.whl", hash = "sha256:3afb05607b89aed0ffe25202399ee0867ad4d3cb4180d98aaf8eefa6a5f7d475"},
+    {file = "termcolor-2.3.0.tar.gz", hash = "sha256:b5b08f68937f138fe92f6c089b99f1e2da0ae56c52b78bf7075fd95420fd9a5a"},
+]
+
+[package.extras]
+tests = ["pytest", "pytest-cov"]
+
+[[package]]
 name = "terminado"
 version = "0.17.1"
 description = "Tornado websocket backend for the Xterm.js Javascript terminal emulator library."
@@ -3993,4 +4026,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "2e62bee33b9ec8c546534a321345d1632d5e563abe2d286c009d0ea3fa7bdfec"
+content-hash = "615b6e5aa856d4f6cadfdbbfa9d14a106f62c5514cb44eb8b5fcd481f70ad6e8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ safetensors = "^0.3.1"
 attrs = "^23.1.0"
 parameterized = "^0.9.0"
 pytest = "^7.3.2"
+pytest-sugar = "^0.9.7"
 subaudit = "^0.1.0"
 
 [tool.poetry.group.lint.dependencies]
@@ -107,7 +108,7 @@ legacy_tox_ini = """
         poetry export --only=test --output={env_tmp_dir}/requirements_test.txt
         pip install -qr {env_tmp_dir}/requirements_test.txt
     commands =
-        pytest --color=yes
+        pytest --color=yes --force-sugar
     setenv =
         TESTS_CACHE_EMBEDDING_CALLS_IN_MEMORY = yes
 


### PR DESCRIPTION
The [`pytest-sugar`](https://github.com/Teemu/pytest-sugar/#readme) plugin changes the style of `pytest` output. It's subjective whether the visual appearance is better or worse than the default. However, one benefit is that it shows detailed information about each failed test immediately, rather than waiting until other tests have run. This is something I recall we've wished we had on several occasions when pair coding on this project.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/sugar) for unit test status, though this shouldn't affect that (our CI doesn't use the `pytest` runner).