### PR TITLE
Use latest ipython compatible with Python version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1266,6 +1266,45 @@ test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
 test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.21)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
 
 [[package]]
+name = "ipython"
+version = "8.14.0"
+description = "IPython: Productive Interactive Computing"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "ipython-8.14.0-py3-none-any.whl", hash = "sha256:248aca623f5c99a6635bc3857677b7320b9b8039f99f070ee0d20a5ca5a8e6bf"},
+    {file = "ipython-8.14.0.tar.gz", hash = "sha256:1d197b907b6ba441b692c48cf2a3a2de280dc0ac91a3405b39349a50272ca0a1"},
+]
+
+[package.dependencies]
+appnope = {version = "*", markers = "sys_platform == \"darwin\""}
+backcall = "*"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+decorator = "*"
+jedi = ">=0.16"
+matplotlib-inline = "*"
+pexpect = {version = ">4.3", markers = "sys_platform != \"win32\""}
+pickleshare = "*"
+prompt-toolkit = ">=3.0.30,<3.0.37 || >3.0.37,<3.1.0"
+pygments = ">=2.4.0"
+stack-data = "*"
+traitlets = ">=5"
+typing-extensions = {version = "*", markers = "python_version < \"3.10\""}
+
+[package.extras]
+all = ["black", "curio", "docrepr", "ipykernel", "ipyparallel", "ipywidgets", "matplotlib", "matplotlib (!=3.2.0)", "nbconvert", "nbformat", "notebook", "numpy (>=1.21)", "pandas", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio", "qtconsole", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "trio", "typing-extensions"]
+black = ["black"]
+doc = ["docrepr", "ipykernel", "matplotlib", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "typing-extensions"]
+kernel = ["ipykernel"]
+nbconvert = ["nbconvert"]
+nbformat = ["nbformat"]
+notebook = ["ipywidgets", "notebook"]
+parallel = ["ipyparallel"]
+qtconsole = ["qtconsole"]
+test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
+test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.21)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
+
+[[package]]
 name = "isoduration"
 version = "20.11.0"
 description = "Operations with ISO 8601 durations"
@@ -4026,4 +4065,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "615b6e5aa856d4f6cadfdbbfa9d14a106f62c5514cb44eb8b5fcd481f70ad6e8"
+content-hash = "95ea39b32b6661b72b25e7c714a4105fc008088d52fffd16dfa0ba9c4877fea8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,10 @@ pylint-sarif-unofficial = "^0.1.0"
 [tool.poetry.group.notebook.dependencies]
 graphviz = "^0.20.1"
 ipykernel = "^6.23.2"
+ipython = [
+    { version = "~8.12.2", python = "<3.9" },
+    { version = "^8.14.0", python = ">=3.9" },
+]
 jupyter-collaboration = "^1.0.0"
 jupyterlab = "^4.0.2"
 nbdime = "^3.2.1"


### PR DESCRIPTION
This is analogous to #174, but for `ipython`. This is less important than being able to use the latest `numpy`, but still useful. In particular, being able to use the newest `ipython` restores the right arrow for completing a whole line, which had become broken.

Unlike `numpy`, `ipython` was not previously listed in `pyproject.toml`, so this is adding that item as a list, rather than changing it to be a list.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/ipy) for unit test status, though that should be unaffected.