### PR TITLE
Make usc_42.ipynb code clearer and more robust

### DIFF
--- a/embed/__init__.py
+++ b/embed/__init__.py
@@ -3,6 +3,7 @@
 __all__ = [
     'cached',
     'DIMENSION',
+    'CONTEXT_LENGTH',
     'count_tokens',
     'embed_one',
     'embed_many',
@@ -29,6 +30,11 @@ _keys.initialize(__name__)
 
 DIMENSION = 1536
 """Dimension of the vector space text-embedding-ada-002 embeds texts in."""
+
+CONTEXT_LENGTH = 8191
+"""
+Maximum length in cl100k_base tokens that text-embedding-ada-002 can embed.
+"""
 
 _REQUESTS_TIMEOUT = datetime.timedelta(seconds=60)
 """Connection timeout for ``embed_one_req`` and ``embed_many_req``."""

--- a/notebooks/demos/usc_42.ipynb
+++ b/notebooks/demos/usc_42.ipynb
@@ -10,6 +10,7 @@
     "import contextlib\n",
     "from copy import deepcopy\n",
     "import itertools\n",
+    "import logging\n",
     "from pathlib import Path\n",
     "from pprint import pp\n",
     "import textwrap\n",
@@ -29,7 +30,11 @@
    "outputs": [],
    "source": [
     "def output_box(enable=True, *, height='28em'):\n",
-    "    \"\"\"Context manager to limit output height, giving a vertical scrollbar.\"\"\"\n",
+    "    \"\"\"\n",
+    "    Context manager to limit output height, giving a vertical scrollbar.\n",
+    "\n",
+    "    Be aware that boxed output is not typically saved saved in the .ipynb file.\n",
+    "    \"\"\"\n",
     "    if not enable:  # This lets the user easily \"unbox\" and \"rebox\" the cell.\n",
     "        return contextlib.nullcontext()\n",
     "\n",
@@ -311,7 +316,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#sum(1 for section in sections if count_tokens_xml(section) > 8191)"
+    "# sum(\n",
+    "#     1 for section in sections\n",
+    "#     if count_tokens_xml(section) > embed.CONTEXT_LENGTH\n",
+    "# )"
    ]
   },
   {
@@ -431,11 +439,11 @@
     {
      "data": {
       "text/plain": [
-       "{<Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f7c0ad46d40>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f7c0ad4c100>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f7c0ad4c1c0>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f7c0ad4c240>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f7c0b3d76c0>}"
+       "{<Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fd0a4747840>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fd0a4747880>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fd0a4747940>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fd0a47479c0>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fd0a64abb80>}"
       ]
      },
      "execution_count": 27,
@@ -456,7 +464,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<subsection xmlns=\"http://xml.house.gov/schemas/uslm/1.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" style=\"-uslm-lc:I21\" class=\"indent0\" status=\"repealed\"><num value=\"b\">“[(b)</num><content> Repealed. <ref href=\"/us/pl/116/159/dA/s156/d/1\">Pub. L. 116–159, div. A, § 156(d)(1)</ref>, <date date=\"2020-10-01\">Oct. 1, 2020</date>, <ref href=\"/us/stat/134/721\">134 Stat. 721</ref>.]</content>\n",
+      "<subsection xmlns=\"http://xml.house.gov/schemas/uslm/1.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" style=\"-uslm-lc:I21\" class=\"indent0\" status=\"repealed\"><num value=\"d\">“[(d)</num><content> Repealed. <ref href=\"/us/pl/109/482/tI/s104/b/3/E\">Pub. L. 109–482, title I, § 104(b)(3)(E)</ref>, <date date=\"2007-01-15\">Jan. 15, 2007</date>, <ref href=\"/us/stat/120/3694\">120 Stat. 3694</ref>.]</content>\n",
       "</subsection>\n",
       "\n"
      ]
@@ -517,7 +525,10 @@
     }
    ],
    "source": [
-    "sum(1 for section in sections if count_tokens_xml_clean(section) > 8191)"
+    "sum(\n",
+    "    1 for section in sections\n",
+    "    if count_tokens_xml_clean(section) > embed.CONTEXT_LENGTH\n",
+    ")"
    ]
   },
   {
@@ -526,7 +537,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "too_long_count = [count for section in sections if (count := count_tokens_xml_clean(section)) > 8191]"
+    "too_long_count = [\n",
+    "    count for section in sections\n",
+    "    if (count := count_tokens_xml_clean(section)) > embed.CONTEXT_LENGTH\n",
+    "]"
    ]
   },
   {
@@ -557,7 +571,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8be6fa7fa7914a1ca51e4bf83e52895c",
+       "model_id": "df06e2a342704c5282e2fa94666efe25",
        "version_major": 2,
        "version_minor": 0
       },
@@ -582,7 +596,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "12ff69b11c274435ba68ad86950c2f9b",
+       "model_id": "bfd50f158c734395a361cde5718ec6f6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -598,7 +612,7 @@
     "too_long = Counter({\n",
     "    section.attrib['identifier']: count\n",
     "    for section in sections\n",
-    "    if (count := count_tokens_xml_clean(section)) > 8191\n",
+    "    if (count := count_tokens_xml_clean(section)) > embed.CONTEXT_LENGTH\n",
     "})\n",
     "\n",
     "with output_box():\n",
@@ -613,7 +627,7 @@
     {
      "data": {
       "text/plain": [
-       "<Element {http://xml.house.gov/schemas/uslm/1.0}section at 0x7f7c0a2c0e40>"
+       "<Element {http://xml.house.gov/schemas/uslm/1.0}section at 0x7fd0a4ab1f80>"
       ]
      },
      "execution_count": 37,
@@ -654,7 +668,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "32a70e6b35b64e75b92609723b036e56",
+       "model_id": "3fbc8fbd821b4c08b28c60349eaf62ec",
        "version_major": 2,
        "version_minor": 0
       },
@@ -679,8 +693,8 @@
     {
      "data": {
       "text/plain": [
-       "[<Element {http://xml.house.gov/schemas/uslm/1.0}meta at 0x7f7c09eca200>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}main at 0x7f7c09ec9180>]"
+       "[<Element {http://xml.house.gov/schemas/uslm/1.0}meta at 0x7fd0a46d2400>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}main at 0x7fd0a46d1f80>]"
       ]
      },
      "execution_count": 40,
@@ -777,7 +791,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "94d8c8ab5a784390b68724e1e2bf171f",
+       "model_id": "81be054d1bea4a56948be3fdeaa9a1a0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -829,7 +843,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "818a56c44aba4d6aa2ce5f975e05297f",
+       "model_id": "e860e3230b72463bb4643aafe8f7a9a4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -960,7 +974,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "605903540c964e1dbac2844d748573ed",
+       "model_id": "31452f335d454a48be7b74dc319f97a3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -975,8 +989,8 @@
    "source": [
     "with output_box():\n",
     "    treeit = ET.iterwalk(usc42root, events=('start',), tag=section_tag)\n",
-    "    for event, elem in treeit: \n",
-    "        print(elem)"
+    "    for event, element in treeit: \n",
+    "        print(element)"
    ]
   },
   {
@@ -1006,12 +1020,14 @@
    "outputs": [],
    "source": [
     "def get_direct_sections(root):\n",
-    "    it = ET.iterwalk(root, events=('start',), tag=section_tag)\n",
-    "    for _, elem in it:\n",
-    "        it.skip_subtree()\n",
-    "        yield elem\n",
+    "    selection = []\n",
+    "    iterator = ET.iterwalk(root, events=('start',), tag=section_tag)\n",
+    "    for _, element in iterator:\n",
+    "        iterator.skip_subtree()\n",
+    "        selection.append(element)\n",
+    "    return selection\n",
     "\n",
-    "direct_sections = list(get_direct_sections(usc42root))"
+    "direct_sections = get_direct_sections(usc42root)"
    ]
   },
   {
@@ -1022,7 +1038,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f922db395fa84699ab9dae11c183cb5f",
+       "model_id": "9e769edd3e5a40af9c0fa90ed6951257",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1085,7 +1101,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "too_long_count_direct = [count for section in direct_sections if (count := count_tokens_xml_clean(section)) > 8191]"
+    "too_long_count_direct = [\n",
+    "    count for section in direct_sections\n",
+    "    if (count := count_tokens_xml_clean(section)) > embed.CONTEXT_LENGTH\n",
+    "]"
    ]
   },
   {
@@ -1116,7 +1135,7 @@
     {
      "data": {
       "text/plain": [
-       "17.799698600000056"
+       "17.9874848999998"
       ]
      },
      "execution_count": 59,
@@ -1126,7 +1145,9 @@
    ],
    "source": [
     "start_time = time.perf_counter()\n",
-    "direct_section_token_counts = [count_tokens_xml_clean(section) for section in direct_sections]\n",
+    "direct_section_token_counts = [\n",
+    "    count_tokens_xml_clean(section) for section in direct_sections\n",
+    "]\n",
     "end_time = time.perf_counter()\n",
     "end_time - start_time"
    ]
@@ -1144,14 +1165,20 @@
     "#            logical portions of the U.S. Code.\n",
     "#\n",
     "def get_embeddable_elements(section):\n",
-    "    it = ET.iterwalk(section, events=('start',))\n",
-    "    for _, elem in it:\n",
-    "        token_count = count_tokens_xml_clean(elem)\n",
-    "        if token_count <= 8191:  # We can embed this subtree.\n",
-    "            it.skip_subtree()\n",
-    "            yield elem\n",
-    "        elif len(elem) == 0:  # We're at the bottom and it's still too big.\n",
-    "            print(f'Too-big leaf f{elem} ({token_count} tokens).')"
+    "    selection = []\n",
+    "    iterator = ET.iterwalk(section, events=('start',))\n",
+    "\n",
+    "    for _, element in iterator:\n",
+    "        token_count = count_tokens_xml_clean(element)\n",
+    "        \n",
+    "        if token_count <= embed.CONTEXT_LENGTH:  # We can embed this subtree.\n",
+    "            iterator.skip_subtree()\n",
+    "            selection.append(element)\n",
+    "        elif len(element) == 0:  # We're at the bottom and it's still too big.\n",
+    "            logging.error(f'Too-big leaf %r (%d tokens).',\n",
+    "                          element, token_count)\n",
+    "    \n",
+    "    return selection"
    ]
   },
   {
@@ -1161,7 +1188,7 @@
    "outputs": [],
    "source": [
     "# We might try to embed it this way (one embedding per row element).\n",
-    "breakdowns = [list(get_embeddable_elements(section)) for section in direct_sections]"
+    "breakdowns = [get_embeddable_elements(section) for section in direct_sections]"
    ]
   },
   {
@@ -1272,7 +1299,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0d273f0c04f34c789a5d83a6f4e37a16",
+       "model_id": "52b056e3055f4181a854ad456e0b131e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1341,7 +1368,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "160afef6498a4362aff2966a2559e293",
+       "model_id": "52f914f12f2e4f2c833366fb9110b332",
        "version_major": 2,
        "version_minor": 0
       },

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -18,9 +18,22 @@ from tests import _bases
 class TestStats(_bases.TestBase):
     """Tests for model dimension and token encoding facilites in ``embed``."""
 
+    # TODO: Decide if we should really have test_model_dimension_is_1536 and
+    #       test_model_context_length_is_8191, given that they contain the same
+    #       information as the code under test. If we can access another source
+    #       to validate this information, then it may make sense to retain it.
+    #       Otherwise, those two test cases may not be very valuable, though
+    #       since other tests rely on these values, that may justify the tests.
+
     def test_model_dimension_is_1536(self):
         """``DIMENSION``'s value is correct for ``text-embedding-ada-002``."""
         self.assertEqual(embed.DIMENSION, 1536)
+
+    def test_model_context_length_is_8191(self):
+        """
+        ``CONTEXT_LENGTH``'s value is correct for ``text-embedding-ada-002``.
+        """
+        self.assertEqual(embed.CONTEXT_LENGTH, 8191)
 
     @parameterized.expand([
         ('The cat runs.', 4),


### PR DESCRIPTION
**This is a request to merge commits into the [`usc`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/usc) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

This includes (but is far from limited to) adding a constant to an existing *module* in the project, so changes are not limited to notebooks.

Overall, this:

1. Adds a `CONTEXT_LENGTH` constant to the embed module (modifying that module and its tests, and adding a comment to its tests about deciding in the future if we really want to have trivial unit tests for constants in the embed module), and uses it in the `usc_42.ipynb` notebook. (In the future, other code will make use of it, but that is the case for other things we are doing in the `usc_*.ipynb` notebooks.)

2. Has `get_embeddable_elements` report leaves it cannot break up (if any) using `logging.error` instead of the `print` builtin.

3. Has `get_embeddable_elements` build the list itself, making it no longer a generator function. This is because, however it is to be reported, errors/warnings about leaves that are too big to break up should be reported immediately, rather than at some future time and interleaved with other operations. Furthermore, in the future this will probably raise an exception rather than just output a message, and that is even less desirable to put off until an uncertain future time. (In the way we're currently using the function, none of this applies, but the call site does become simpler, since it need not materialize the results.)

4. Makes the corresponding change to `get_direct_sections` as in (3), so it builds and returns a list rather than being a generator function. This is to avoid making the code harder to read by having the two related functions unnecessarily implemented in different ways, but its call site is likewise simplified.

5. Includes important usage guidance in `output_box`'s docstring.

6. Makes other, smaller changes throughout, for readability.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/usc-next) for unit test status.