### PR TITLE
Our element-to-string conversions include tail text

### DIFF
--- a/notebooks/demos/usc_manual.ipynb
+++ b/notebooks/demos/usc_manual.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -23,6 +24,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -418,6 +420,7 @@
       "</note>\n",
       "<note style=\"-uslm-lc:I74\" role=\"crossHeading\" topic=\"editorialNotes\" id=\"idc8fb1a38-d96f-11ed-bd9a-904c91f2bbbe\"><heading class=\"centered\"><b>Editorial Notes</b></heading></note>\n",
       "<note style=\"-uslm-lc:I75\" topic=\"referencesInText\" id=\"idc8fb1a39-d96f-11ed-bd9a-904c91f2bbbe\">\n",
+      "\n",
       "<heading class=\"centered smallCaps\">References in Text</heading><p style=\"-uslm-lc:I21\" class=\"indent0\">Section 6(j)(1)(A) of the Export Administration Act of 1979, referred to in subsec. (e)(2)(B)(ii), which was classified to section 2405(j)(1)(A) of the former Appendix to Title 50, War and National Defense, prior to editorial reclassification and renumbering as <ref href=\"/us/usc/t50/s4605/j/1/A\">section 4605(j)(1)(A) of Title 50</ref>, was repealed by <ref href=\"/us/pl/115/232/dA/tXVII/s1766/a\">Pub. L. 115–232, div. A, title XVII, § 1766(a)</ref>, <date date=\"2018-08-13\">Aug. 13, 2018</date>, <ref href=\"/us/stat/132/2232\">132 Stat. 2232</ref>.</p>\n",
       "</note>\n",
       "<note style=\"-uslm-lc:I74\" topic=\"amendments\" id=\"idc8fb1a3a-d96f-11ed-bd9a-904c91f2bbbe\"><heading class=\"centered smallCaps\">Amendments</heading><p style=\"-uslm-lc:I21\" class=\"indent0\">2022—<ref href=\"/us/pl/117/263\">Pub. L. 117–263</ref> amended section generally. Prior to amendment, section related to requirements for transmitting the text of United States international agreements and various reports to Congress.</p>\n",
@@ -594,6 +597,7 @@
       "</note>\n",
       "<note><heading><b>Editorial Notes</b></heading></note>\n",
       "<note>\n",
+      "\n",
       "<heading>References in Text</heading><p>Section 6(j)(1)(A) of the Export Administration Act of 1979, referred to in subsec. (e)(2)(B)(ii), which was classified to section 2405(j)(1)(A) of the former Appendix to Title 50, War and National Defense, prior to editorial reclassification and renumbering as <ref>section 4605(j)(1)(A) of Title 50</ref>, was repealed by <ref>Pub. L. 115–232, div. A, title XVII, § 1766(a)</ref>, <date>Aug. 13, 2018</date>, <ref>132 Stat. 2232</ref>.</p>\n",
       "</note>\n",
       "<note><heading>Amendments</heading><p>2022—<ref>Pub. L. 117–263</ref> amended section generally. Prior to amendment, section related to requirements for transmitting the text of United States international agreements and various reports to Congress.</p>\n",
@@ -742,7 +746,7 @@
     {
      "data": {
       "text/plain": [
-       "array([0.7156805 , 0.73955655, 0.7810945 , 0.7316635 ], dtype=float32)"
+       "array([0.715734  , 0.7392469 , 0.781133  , 0.73159194], dtype=float32)"
       ]
      },
      "execution_count": 17,
@@ -764,10 +768,10 @@
     {
      "data": {
       "text/plain": [
-       "array([[0.6938791 , 0.69476515, 0.6941782 ],\n",
-       "       [0.70436895, 0.71381646, 0.70902956],\n",
-       "       [0.75279796, 0.7578374 , 0.7688054 ],\n",
-       "       [0.70862347, 0.71103317, 0.72231287]], dtype=float32)"
+       "array([[0.6938859 , 0.69473076, 0.69403136],\n",
+       "       [0.7043189 , 0.7137102 , 0.70869833],\n",
+       "       [0.7527983 , 0.7574674 , 0.76853406],\n",
+       "       [0.7086115 , 0.71086514, 0.72208804]], dtype=float32)"
       ]
      },
      "execution_count": 18,
@@ -790,7 +794,7 @@
     {
      "data": {
       "text/plain": [
-       "array([0.78910667, 0.7625172 , 0.7477622 , 0.7337751 ], dtype=float32)"
+       "array([0.7890711 , 0.76216185, 0.7475041 , 0.7333307 ], dtype=float32)"
       ]
      },
      "execution_count": 19,
@@ -811,7 +815,7 @@
     {
      "data": {
       "text/plain": [
-       "array([0.7321866 , 0.76482606, 0.7399651 , 0.7473894 ], dtype=float32)"
+       "array([0.7314263 , 0.7645397 , 0.73998594, 0.7471187 ], dtype=float32)"
       ]
      },
      "execution_count": 20,
@@ -832,7 +836,7 @@
     {
      "data": {
       "text/plain": [
-       "array([0.7103989 , 0.72968125, 0.72913504, 0.7074885 ], dtype=float32)"
+       "array([0.71030784, 0.72951204, 0.72880983, 0.7073054 ], dtype=float32)"
       ]
      },
      "execution_count": 21,
@@ -848,26 +852,149 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Parsing experiments"
+    "## `tail` text in selected fragments"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_tails(root):\n",
+    "    for _, element in ET.iterwalk(root, events=('start',)):\n",
+    "        if element.tail and element.tail.strip():\n",
+    "            print(f'{element}: {element.tail!r}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<Element date at 0x7f01731f0d40>: ', and at yearly intervals thereafter, the President shall, under his own signature, transmit to the Speaker of the House of Representatives and the chairman of the Committee on Foreign Relations of the Senate a report with respect to each international agreement which, during the preceding year, was transmitted to the Congress after the expiration of the 60-day period referred to in the first sentence of subsection (a), describing fully and completely the reasons for the late transmittal.'\n",
+      "<Element note at 0x7f013054ea00>: ' of the Export Administration Act of 1979 (50 U.S.C. App. 2405(j)(1)(A)), section 620A(a) of the Foreign Assistance Act of 1961 ('\n",
+      "<Element num at 0x7f013054e800>: '\\u202fSee References in Text note below.'\n",
+      "<Element ref at 0x7f013054e280>: '), or section 40(d) of the Arms Export Control Act ('\n",
+      "<Element ref at 0x7f013054e400>: ').'\n",
+      "<Element ref at 0x7f01731f0d40>: ', '\n",
+      "<Element date at 0x7f013054e280>: ', '\n",
+      "<Element ref at 0x7f0130a330c0>: '; amended '\n",
+      "<Element ref at 0x7f013054e400>: ', '\n",
+      "<Element date at 0x7f01731f0d40>: ', '\n",
+      "<Element ref at 0x7f013054e280>: '; '\n",
+      "<Element ref at 0x7f0130a330c0>: ', '\n",
+      "<Element date at 0x7f013054e400>: ', '\n",
+      "<Element ref at 0x7f01731f0d40>: '; '\n",
+      "<Element ref at 0x7f013054e280>: ', '\n",
+      "<Element date at 0x7f0130a330c0>: ', '\n",
+      "<Element ref at 0x7f013054e400>: '; '\n",
+      "<Element ref at 0x7f01731f0d40>: '–(d), '\n",
+      "<Element date at 0x7f013054e400>: ', '\n",
+      "<Element ref at 0x7f0130a330c0>: ', 3808; '\n",
+      "<Element ref at 0x7f013054e280>: ', '\n",
+      "<Element date at 0x7f01731f0d40>: ', '\n",
+      "<Element ref at 0x7f013054e400>: '; '\n",
+      "<Element ref at 0x7f0130a330c0>: ', '\n",
+      "<Element date at 0x7f013054e280>: ', '\n",
+      "<Element ref at 0x7f01731f0d40>: '.)'\n",
+      "<Element ref at 0x7f0130a330c0>: ', (c), '\n",
+      "<Element date at 0x7f013054dfc0>: ', '\n",
+      "<Element ref at 0x7f013054d000>: ', 3482, provided that, effective 270 days after '\n",
+      "<Element date at 0x7f013054dfc0>: ', this section is amended to read as follows:'\n",
+      "<Element ref at 0x7f013054d000>: ' note; relating to classified national security information) or any predecessor or successor order, or that contain any information that is otherwise exempt from public disclosure pursuant to United States law.'\n",
+      "<Element ref at 0x7f0130a330c0>: ' et seq.) or the Food for Peace Act ('\n",
+      "<Element ref at 0x7f013054cd80>: ' et seq.).'\n",
+      "<Element ref at 0x7f0131f371c0>: ').'\n",
+      "<Element ref at 0x7f01731f0d40>: ', was repealed by '\n",
+      "<Element ref at 0x7f013054cd80>: ', '\n",
+      "<Element date at 0x7f013054dfc0>: ', '\n",
+      "<Element ref at 0x7f013054d000>: '.'\n",
+      "<Element ref at 0x7f01731f0d40>: ' amended section generally. Prior to amendment, section related to requirements for transmitting the text of United States international agreements and various reports to Congress.'\n",
+      "<Element ref at 0x7f01731f0d40>: ' added subsec. (g).'\n",
+      "<Element ref at 0x7f01731f0d40>: ', substituted “Committee on International Relations” for “Committee on Foreign Affairs”.'\n",
+      "<Element ref at 0x7f01731f0d40>: ', added subsec. (d). Former subsec. (d) redesignated (e).'\n",
+      "<Element ref at 0x7f01731f0d40>: ', designated existing provisions as par. (1), substituted “Subject to paragraph (2), the Secretary of State” for “The Secretary of State”, and added par. (2).'\n",
+      "<Element ref at 0x7f01731f0d40>: ', redesignated subsec. (d) as (e). Former subsec. (e) redesignated (f).'\n",
+      "<Element ref at 0x7f01731f0d40>: ', redesignated subsec. (e) as (f).'\n",
+      "<Element ref at 0x7f01731f0d40>: ' substituted “Committee on Foreign Affairs” for “Committee on International Relations”.'\n",
+      "<Element ref at 0x7f01731f0d40>: ' designated existing provisions as subsec. (a), inserted “(including the text of any oral international agreement, which agreement shall be reduced to writing)”, and added subsecs. (b) to (e).'\n",
+      "<Element ref at 0x7f01731f0d40>: ' substituted “Committee on International Relations of the House of Representatives” for “Committee on Foreign Affairs of the House of Representatives” and inserted requirement that any department or agency of the United States Government which enters into any international agreement on behalf of the United States transmit to the Department of State the text of such agreement not later than twenty days after the agreement has been signed.'\n",
+      "<Element date at 0x7f0131f371c0>: '.'\n",
+      "<Element ref at 0x7f0131f371c0>: ' effective 270 days after '\n",
+      "<Element date at 0x7f013054d000>: ', see '\n",
+      "<Element ref at 0x7f013054cd80>: ', set out as a note under '\n",
+      "<Element ref at 0x7f013054d000>: '.'\n",
+      "<Element ref at 0x7f0130a330c0>: ', '\n",
+      "<Element date at 0x7f013054dfc0>: ', '\n",
+      "<Element ref at 0x7f013054cd80>: ', provided that: '\n",
+      "<Element date at 0x7f0130a330c0>: '], the President, through the Secretary of State, shall promulgate such rules and regulations as may be necessary to carry out '\n",
+      "<Element ref at 0x7f013054d000>: ', United States Code, as amended by paragraph (1).”'\n",
+      "<Element date at 0x7f0130a330c0>: ', of provisions of law requiring submittal to Congress of any annual, semiannual, or other regular periodic report listed in House Document No. 103–7 (in which the report required by subsec. (b) of this section is listed on page 38), see '\n",
+      "<Element ref at 0x7f013054dfc0>: ', as amended, set out as a note under '\n",
+      "<Element ref at 0x7f013054d000>: ', Money and Finance.'\n",
+      "<Element ref at 0x7f0130a330c0>: ', '\n",
+      "<Element date at 0x7f013054cd80>: ', '\n",
+      "<Element ref at 0x7f013054dfc0>: ', provided that: '\n",
+      "<Element date at 0x7f0130a330c0>: '], the Secretary of State shall establish a mechanism for personnel of the Department of State who become aware or who have reason to believe that the requirements under '\n",
+      "<Element ref at 0x7f013054d000>: ', United States Code, as amended by paragraph (1), have not been fulfilled with respect to an international agreement or qualifying non-binding instrument (as such terms are defined in such section) to report such instances to the Secretary.”'\n",
+      "<Element ref at 0x7f0130a330c0>: ', '\n",
+      "<Element date at 0x7f013054dfc0>: ', '\n",
+      "<Element ref at 0x7f013054cd80>: ', provided that:'\n",
+      "<Element inline at 0x7f013054cd80>: '.—'\n",
+      "<Element ref at 0x7f013054cd80>: ', and '\n",
+      "<Element ref at 0x7f013054e800>: ', Domestic Security, and enacting provisions set out as notes under this section and '\n",
+      "<Element ref at 0x7f013054d000>: '] and the amendments made by this section before and after the effective date described in subsection (c) [see Effective Date of 2022 Amendment note set out under '\n",
+      "<Element ref at 0x7f013054cd80>: '].'\n",
+      "<Element inline at 0x7f0130a330c0>: '.—'\n",
+      "<Element date at 0x7f0130a330c0>: '], and once every 90 days thereafter for 1 year, the Secretary shall brief the Committee on Foreign Relations of the Senate, the Committee on Appropriations of the Senate, the Committee on Foreign Affairs of the House of Representatives, and the Committee on Appropriations of the House of Representatives regarding the status of efforts to implement this section and the amendments made by this section.”'\n",
+      "<Element ref at 0x7f0130a330c0>: ', '\n",
+      "<Element date at 0x7f013054e500>: ', '\n",
+      "<Element ref at 0x7f013054dfc0>: ', as amended by '\n",
+      "<Element ref at 0x7f013054e500>: ', '\n",
+      "<Element date at 0x7f013054d000>: ', '\n",
+      "<Element ref at 0x7f013054dfc0>: ', provided that:'\n",
+      "<Element inline at 0x7f013054dfc0>: '.—'\n",
+      "<Element ref at 0x7f013054dfc0>: ', United States Code (commonly referred to as the ‘Case-Zablocki Act’), is not so transmitted within the 60-day period specified in that sentence, then no funds authorized to be appropriated by this or any other Act shall be available after the end of that 60-day period to implement that agreement until the text of that agreement has been so transmitted.'\n",
+      "<Element inline at 0x7f0130a330c0>: '.—'\n",
+      "<Element date at 0x7f0130a330c0>: '] and shall apply during fiscal years 2005, 2006, and 2007.”'\n"
+     ]
+    }
+   ],
+   "source": [
+    "show_tails(ET.fromstring(S112B))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `text` text and `tail` text experiments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
     "P_ELEMENT = \"\"\"<p>\n",
-    "  We have assumed <strong>all</strong> important text is located in a <em>leaf</em> of the tree.\n",
+    "  We had assumed <strong>all</strong> important text is located in a <em>leaf</em> of the tree.\n",
     "</p>\"\"\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -876,16 +1003,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'\\n  We have assumed '"
+       "'\\n  We had assumed '"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -896,7 +1023,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -905,7 +1032,7 @@
        "True"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -916,16 +1043,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<Element strong at 0x213e252c700>, <Element em at 0x213e252f380>]"
+       "[<Element strong at 0x7f013054f800>, <Element em at 0x7f013054c540>]"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -937,7 +1064,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -946,7 +1073,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -955,7 +1082,7 @@
        "'all'"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -966,7 +1093,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -975,7 +1102,7 @@
        "' important text is located in a '"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -986,7 +1113,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'<strong>all</strong> important text is located in a '"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ET.tostring(strong, encoding='unicode')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -995,7 +1142,7 @@
        "'leaf'"
       ]
      },
-     "execution_count": 59,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1006,7 +1153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -1015,7 +1162,7 @@
        "' of the tree.\\n'"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1026,128 +1173,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# TODO: Check if tail text is somehow preserved when an element is converted to a string."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 49,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def show_tails(root):\n",
-    "    for _, element in ET.iterwalk(root, events=('start',)):\n",
-    "        if element.tail is None:\n",
-    "            continue\n",
-    "        tail = element.tail.strip()\n",
-    "        if tail:\n",
-    "            print(f'{element}: {element.tail!r}')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<Element date at 0x213e45ead00>: ', and at yearly intervals thereafter, the President shall, under his own signature, transmit to the Speaker of the House of Representatives and the chairman of the Committee on Foreign Relations of the Senate a report with respect to each international agreement which, during the preceding year, was transmitted to the Congress after the expiration of the 60-day period referred to in the first sentence of subsection (a), describing fully and completely the reasons for the late transmittal.'\n",
-      "<Element note at 0x213e45f7180>: ' of the Export Administration Act of 1979 (50 U.S.C. App. 2405(j)(1)(A)), section 620A(a) of the Foreign Assistance Act of 1961 ('\n",
-      "<Element num at 0x213e45f4d40>: '\\u202fSee References in Text note below.'\n",
-      "<Element ref at 0x213e45f6dc0>: '), or section 40(d) of the Arms Export Control Act ('\n",
-      "<Element ref at 0x213e45f4e00>: ').'\n",
-      "<Element ref at 0x213e45f4e00>: ', '\n",
-      "<Element date at 0x213e45f5540>: ', '\n",
-      "<Element ref at 0x213e45f4d40>: '; amended '\n",
-      "<Element ref at 0x213e45f5580>: ', '\n",
-      "<Element date at 0x213e45f5540>: ', '\n",
-      "<Element ref at 0x213e45f4d40>: '; '\n",
-      "<Element ref at 0x213e45f4e00>: ', '\n",
-      "<Element date at 0x213e45f5580>: ', '\n",
-      "<Element ref at 0x213e45f5540>: '; '\n",
-      "<Element ref at 0x213e45f4d40>: ', '\n",
-      "<Element date at 0x213e45f4e00>: ', '\n",
-      "<Element ref at 0x213e45f5580>: '; '\n",
-      "<Element ref at 0x213e45f5540>: '–(d), '\n",
-      "<Element date at 0x213e45f4e00>: ', '\n",
-      "<Element ref at 0x213e45f4d40>: ', 3808; '\n",
-      "<Element ref at 0x213e45f6dc0>: ', '\n",
-      "<Element date at 0x213e45f4e00>: ', '\n",
-      "<Element ref at 0x213e45f4d40>: '; '\n",
-      "<Element ref at 0x213e45f5540>: ', '\n",
-      "<Element date at 0x213e45f6dc0>: ', '\n",
-      "<Element ref at 0x213e45f4e00>: '.)'\n",
-      "<Element ref at 0x213e45f6dc0>: ', (c), '\n",
-      "<Element date at 0x213e45f4140>: ', '\n",
-      "<Element ref at 0x213e45f4d40>: ', 3482, provided that, effective 270 days after '\n",
-      "<Element date at 0x213e45f4c40>: ', this section is amended to read as follows:'\n",
-      "<Element ref at 0x213e45f4140>: ' note; relating to classified national security information) or any predecessor or successor order, or that contain any information that is otherwise exempt from public disclosure pursuant to United States law.'\n",
-      "<Element ref at 0x213e45f4c40>: ' et seq.) or the Food for Peace Act ('\n",
-      "<Element ref at 0x213e45f6dc0>: ' et seq.).'\n",
-      "<Element ref at 0x213e45f4140>: ').'\n",
-      "<Element ref at 0x213e45f4c40>: ', was repealed by '\n",
-      "<Element ref at 0x213e45f4d40>: ', '\n",
-      "<Element date at 0x213e45f6dc0>: ', '\n",
-      "<Element ref at 0x213e45f4140>: '.'\n",
-      "<Element ref at 0x213e45ead00>: ' amended section generally. Prior to amendment, section related to requirements for transmitting the text of United States international agreements and various reports to Congress.'\n",
-      "<Element ref at 0x213e45ead00>: ' added subsec. (g).'\n",
-      "<Element ref at 0x213e45ead00>: ', substituted “Committee on International Relations” for “Committee on Foreign Affairs”.'\n",
-      "<Element ref at 0x213e45ead00>: ', added subsec. (d). Former subsec. (d) redesignated (e).'\n",
-      "<Element ref at 0x213e45ead00>: ', designated existing provisions as par. (1), substituted “Subject to paragraph (2), the Secretary of State” for “The Secretary of State”, and added par. (2).'\n",
-      "<Element ref at 0x213e45ead00>: ', redesignated subsec. (d) as (e). Former subsec. (e) redesignated (f).'\n",
-      "<Element ref at 0x213e45ead00>: ', redesignated subsec. (e) as (f).'\n",
-      "<Element ref at 0x213e45ead00>: ' substituted “Committee on Foreign Affairs” for “Committee on International Relations”.'\n",
-      "<Element ref at 0x213e45ead00>: ' designated existing provisions as subsec. (a), inserted “(including the text of any oral international agreement, which agreement shall be reduced to writing)”, and added subsecs. (b) to (e).'\n",
-      "<Element ref at 0x213e45ead00>: ' substituted “Committee on International Relations of the House of Representatives” for “Committee on Foreign Affairs of the House of Representatives” and inserted requirement that any department or agency of the United States Government which enters into any international agreement on behalf of the United States transmit to the Department of State the text of such agreement not later than twenty days after the agreement has been signed.'\n",
-      "<Element date at 0x213e45f6dc0>: '.'\n",
-      "<Element ref at 0x213e45ead00>: ' effective 270 days after '\n",
-      "<Element date at 0x213e45f4140>: ', see '\n",
-      "<Element ref at 0x213e45f5500>: ', set out as a note under '\n",
-      "<Element ref at 0x213e45f4e00>: '.'\n",
-      "<Element ref at 0x213e45f4e00>: ', '\n",
-      "<Element date at 0x213e45f4140>: ', '\n",
-      "<Element ref at 0x213e45f5500>: ', provided that: '\n",
-      "<Element date at 0x213e45f5500>: '], the President, through the Secretary of State, shall promulgate such rules and regulations as may be necessary to carry out '\n",
-      "<Element ref at 0x213e45f4d40>: ', United States Code, as amended by paragraph (1).”'\n",
-      "<Element date at 0x213e45ead00>: ', of provisions of law requiring submittal to Congress of any annual, semiannual, or other regular periodic report listed in House Document No. 103–7 (in which the report required by subsec. (b) of this section is listed on page 38), see '\n",
-      "<Element ref at 0x213e45f4e00>: ', as amended, set out as a note under '\n",
-      "<Element ref at 0x213e45f5500>: ', Money and Finance.'\n",
-      "<Element ref at 0x213e45ead00>: ', '\n",
-      "<Element date at 0x213e45f4140>: ', '\n",
-      "<Element ref at 0x213e45f4e00>: ', provided that: '\n",
-      "<Element date at 0x213e45ead00>: '], the Secretary of State shall establish a mechanism for personnel of the Department of State who become aware or who have reason to believe that the requirements under '\n",
-      "<Element ref at 0x213e45f6dc0>: ', United States Code, as amended by paragraph (1), have not been fulfilled with respect to an international agreement or qualifying non-binding instrument (as such terms are defined in such section) to report such instances to the Secretary.”'\n",
-      "<Element ref at 0x213e45ead00>: ', '\n",
-      "<Element date at 0x213e45f4e00>: ', '\n",
-      "<Element ref at 0x213e45f4140>: ', provided that:'\n",
-      "<Element inline at 0x213e45f4140>: '.—'\n",
-      "<Element ref at 0x213e45f4140>: ', and '\n",
-      "<Element ref at 0x213e45f7180>: ', Domestic Security, and enacting provisions set out as notes under this section and '\n",
-      "<Element ref at 0x213e45f4140>: '] and the amendments made by this section before and after the effective date described in subsection (c) [see Effective Date of 2022 Amendment note set out under '\n",
-      "<Element ref at 0x213e45f4d40>: '].'\n",
-      "<Element inline at 0x213e45ead00>: '.—'\n",
-      "<Element date at 0x213e45ead00>: '], and once every 90 days thereafter for 1 year, the Secretary shall brief the Committee on Foreign Relations of the Senate, the Committee on Appropriations of the Senate, the Committee on Foreign Affairs of the House of Representatives, and the Committee on Appropriations of the House of Representatives regarding the status of efforts to implement this section and the amendments made by this section.”'\n",
-      "<Element ref at 0x213e45ead00>: ', '\n",
-      "<Element date at 0x213e45f68c0>: ', '\n",
-      "<Element ref at 0x213e45f4e00>: ', as amended by '\n",
-      "<Element ref at 0x213e45f5500>: ', '\n",
-      "<Element date at 0x213e45f68c0>: ', '\n",
-      "<Element ref at 0x213e45f4e00>: ', provided that:'\n",
-      "<Element inline at 0x213e45f4e00>: '.—'\n",
-      "<Element ref at 0x213e45f4e00>: ', United States Code (commonly referred to as the ‘Case-Zablocki Act’), is not so transmitted within the 60-day period specified in that sentence, then no funds authorized to be appropriated by this or any other Act shall be available after the end of that 60-day period to implement that agreement until the text of that agreement has been so transmitted.'\n",
-      "<Element inline at 0x213e45ead00>: '.—'\n",
-      "<Element date at 0x213e45ead00>: '] and shall apply during fiscal years 2005, 2006, and 2007.”'\n"
-     ]
+     "data": {
+      "text/plain": [
+       "'<em>leaf</em> of the tree.\\n'"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "show_tails(ET.fromstring(S112B))"
+    "ET.tostring(em, encoding='unicode')"
    ]
   },
   {


### PR DESCRIPTION
**This is a request to merge commits into the [`usc`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/usc) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

This adds code to `usc_manual.ipynb` to demonstrate that the way we are converting XML nodes (elements) to strings includes any tail text at the end of the string, even though an element's tail text conceptually belongs to the element's parent.

This may be good or bad, depending on where we want text after a subelement that is not itself part of another subelement to go, in pieces of text whose embeddings we compute. (I suspect that this behavior of `lxml.etree.tostring` may help more than hinder.)

In addition to those additions, this reorders the recently added material in `usc_manual.ipynb` so that it makes more sense when reading the notebook top-down (and so the part we are likely to extend further in the very near future is at the end). This also refactors some of the code there for brevity and readability.

Unit test status can be seen on [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/usc-next), though this should not be able to affect that.