### PR TITLE
Let pylint see inside lxml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ disable = [
 ]
 extension-pkg-allow-list = [
     "blake3",
+    "lxml",
     "orjson",
 ]
 load-plugins = [


### PR DESCRIPTION
**This is a request to merge commits into the [`usc`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/usc) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

This doesn't typically appear needed when `pylint` is run locally, but CI produces `c-extension-no-member`/I1101 for each attribute access expression on `etree` (that is, importing `etree` itself is no problem, but accessing `fromstring`, `tostring`, and `iterwalk` on `etree` produce I1101 diagnostics).

This lists the `lxml` package for `extension-pkg-allow-list`, which already existed to list `blake3` and `orjson`; see 95fa82c (#183).

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/usc-pylint) for unit test status.