### PR TITLE
Improve display of too-long pruned notes' token counts

### DIFF
--- a/notebooks/demos/usc_42.ipynb
+++ b/notebooks/demos/usc_42.ipynb
@@ -408,11 +408,11 @@
     {
      "data": {
       "text/plain": [
-       "{<Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f7556d7bd00>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f7556fcd780>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f7556fce700>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f7556fce780>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f75981c3380>}"
+       "{<Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7febb8656dc0>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7febb8656e80>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7febb88a5880>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7febb9ace540>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7febc6e913c0>}"
       ]
      },
      "execution_count": 24,
@@ -433,7 +433,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<subsection xmlns=\"http://xml.house.gov/schemas/uslm/1.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" style=\"-uslm-lc:I21\" class=\"indent0\" status=\"repealed\"><num value=\"g\">“[(g)</num><content> Repealed. <ref href=\"/us/pl/101/508/tIV/s4118/i/2\">Pub. L. 101–508, title IV, § 4118(i)(2)</ref>, <date date=\"1990-11-05\">Nov. 5, 1990</date>, <ref href=\"/us/stat/104/1388-70\">104 Stat. 1388–70</ref>.]</content>\n",
+      "<subsection xmlns=\"http://xml.house.gov/schemas/uslm/1.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" style=\"-uslm-lc:I21\" class=\"indent0\" status=\"repealed\"><num value=\"c\">“[(c)</num><content> Repealed. <ref href=\"/us/pl/105/276/tV/s582/a/4\">Pub. L. 105–276, title V, § 582(a)(4)</ref>, <date date=\"1998-10-21\">Oct. 21, 1998</date>, <ref href=\"/us/stat/112/2643\">112 Stat. 2643</ref>.]</content>\n",
       "</subsection>\n",
       "\n"
      ]
@@ -492,7 +492,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ac0741a659a54dce9268d026d1219608",
+       "model_id": "8baa45f10688455d9eb0a68404017fd7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -517,7 +517,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2b974e18f568458183af02124c48b579",
+       "model_id": "56c8da60ff76464f94638cdfad11f3d6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -548,7 +548,7 @@
     {
      "data": {
       "text/plain": [
-       "<Element {http://xml.house.gov/schemas/uslm/1.0}section at 0x7f7556d35240>"
+       "<Element {http://xml.house.gov/schemas/uslm/1.0}section at 0x7febb89107c0>"
       ]
      },
      "execution_count": 31,
@@ -589,7 +589,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6f2240728792429eadb60aeb1b777a97",
+       "model_id": "b172c4c9fffd481f9e64e8d78f5968fe",
        "version_major": 2,
        "version_minor": 0
       },
@@ -614,8 +614,8 @@
     {
      "data": {
       "text/plain": [
-       "[<Element {http://xml.house.gov/schemas/uslm/1.0}meta at 0x7f7556f31140>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}main at 0x7f7556f31080>]"
+       "[<Element {http://xml.house.gov/schemas/uslm/1.0}meta at 0x7febb873c5c0>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}main at 0x7febb873c540>]"
       ]
      },
      "execution_count": 34,
@@ -712,7 +712,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9f1e2b2e5f13445babc974733c148e8b",
+       "model_id": "a3e693ca9d1444a1b7895ba768986e44",
        "version_major": 2,
        "version_minor": 0
       },
@@ -764,7 +764,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fcfd3690ce8043aa9149292040c3f7ad",
+       "model_id": "5736564a6e5248199e47230da5cd36cb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -895,7 +895,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a931bdc436fe42e0a242b256bd6f5f32",
+       "model_id": "d0591e65b1db43df823c5a194d4d6db8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -959,7 +959,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d263dc9149f6455783c13bf0f9566f92",
+       "model_id": "3d8cce2e1c794296b8bc7d9107d4901a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1067,7 +1067,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total time elapsed: 18.319912s\n"
+      "Total time elapsed: 17.655874s\n"
      ]
     }
    ],
@@ -1196,7 +1196,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "474497acd1d64fe49438db02008d9167",
+       "model_id": "057c2551e90947258d3f407e55848c04",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1959,6 +1959,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# This doesn't work, because the parents don't always have \"identifier\" attributes.\n",
+    "\n",
     "# too_long_pruned_notes = Counter({\n",
     "#    'notes in ' + notes_element.getparent().attrib['identifier']: count\n",
     "#    for notes_element in pruned_notes\n",
@@ -1975,196 +1977,28 @@
    "outputs": [
     {
      "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "81bb990f34b14254bfad928b60901d36",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "[212559,\n",
-       " 210274,\n",
-       " 140293,\n",
-       " 125228,\n",
-       " 115905,\n",
-       " 114917,\n",
-       " 88486,\n",
-       " 79143,\n",
-       " 76347,\n",
-       " 75712,\n",
-       " 73880,\n",
-       " 64987,\n",
-       " 64786,\n",
-       " 59700,\n",
-       " 57774,\n",
-       " 52409,\n",
-       " 49717,\n",
-       " 49107,\n",
-       " 44490,\n",
-       " 42063,\n",
-       " 40696,\n",
-       " 39807,\n",
-       " 39034,\n",
-       " 35838,\n",
-       " 35783,\n",
-       " 35433,\n",
-       " 32863,\n",
-       " 32273,\n",
-       " 32123,\n",
-       " 31886,\n",
-       " 31292,\n",
-       " 30888,\n",
-       " 30722,\n",
-       " 28962,\n",
-       " 28686,\n",
-       " 27756,\n",
-       " 26890,\n",
-       " 26600,\n",
-       " 26500,\n",
-       " 26264,\n",
-       " 26249,\n",
-       " 25566,\n",
-       " 24379,\n",
-       " 23408,\n",
-       " 22960,\n",
-       " 22754,\n",
-       " 22134,\n",
-       " 22057,\n",
-       " 21874,\n",
-       " 21380,\n",
-       " 21341,\n",
-       " 20973,\n",
-       " 20949,\n",
-       " 20878,\n",
-       " 20761,\n",
-       " 20483,\n",
-       " 20083,\n",
-       " 20077,\n",
-       " 20028,\n",
-       " 18981,\n",
-       " 18565,\n",
-       " 18329,\n",
-       " 18133,\n",
-       " 17554,\n",
-       " 17364,\n",
-       " 17031,\n",
-       " 16970,\n",
-       " 16625,\n",
-       " 16572,\n",
-       " 16449,\n",
-       " 16298,\n",
-       " 16075,\n",
-       " 16012,\n",
-       " 15736,\n",
-       " 15609,\n",
-       " 15516,\n",
-       " 15492,\n",
-       " 15339,\n",
-       " 14643,\n",
-       " 14537,\n",
-       " 14495,\n",
-       " 14393,\n",
-       " 14384,\n",
-       " 14217,\n",
-       " 14088,\n",
-       " 13529,\n",
-       " 13334,\n",
-       " 13140,\n",
-       " 13052,\n",
-       " 12901,\n",
-       " 12783,\n",
-       " 12701,\n",
-       " 12639,\n",
-       " 12584,\n",
-       " 12480,\n",
-       " 12462,\n",
-       " 12430,\n",
-       " 12404,\n",
-       " 12375,\n",
-       " 12355,\n",
-       " 12300,\n",
-       " 12204,\n",
-       " 12199,\n",
-       " 12145,\n",
-       " 12100,\n",
-       " 12078,\n",
-       " 12074,\n",
-       " 12053,\n",
-       " 11915,\n",
-       " 11833,\n",
-       " 11819,\n",
-       " 11811,\n",
-       " 11785,\n",
-       " 11755,\n",
-       " 11727,\n",
-       " 11547,\n",
-       " 11361,\n",
-       " 11348,\n",
-       " 11327,\n",
-       " 11319,\n",
-       " 11191,\n",
-       " 11191,\n",
-       " 11167,\n",
-       " 11145,\n",
-       " 11043,\n",
-       " 10973,\n",
-       " 10968,\n",
-       " 10920,\n",
-       " 10890,\n",
-       " 10883,\n",
-       " 10876,\n",
-       " 10870,\n",
-       " 10853,\n",
-       " 10808,\n",
-       " 10753,\n",
-       " 10692,\n",
-       " 10639,\n",
-       " 10615,\n",
-       " 10513,\n",
-       " 10475,\n",
-       " 10453,\n",
-       " 10302,\n",
-       " 10176,\n",
-       " 10111,\n",
-       " 10081,\n",
-       " 10062,\n",
-       " 10061,\n",
-       " 10053,\n",
-       " 9964,\n",
-       " 9825,\n",
-       " 9807,\n",
-       " 9734,\n",
-       " 9688,\n",
-       " 9673,\n",
-       " 9462,\n",
-       " 9362,\n",
-       " 9331,\n",
-       " 9185,\n",
-       " 9169,\n",
-       " 9086,\n",
-       " 8745,\n",
-       " 8719,\n",
-       " 8606,\n",
-       " 8598,\n",
-       " 8555,\n",
-       " 8549,\n",
-       " 8500,\n",
-       " 8477,\n",
-       " 8471,\n",
-       " 8446,\n",
-       " 8438,\n",
-       " 8418,\n",
-       " 8326,\n",
-       " 8275,\n",
-       " 8238,\n",
-       " 8210,\n",
-       " 8196]"
+       "Output(layout=Layout(height='28em'))"
       ]
      },
-     "execution_count": 75,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "sorted((\n",
+    "# Instead, just examine the token counts for \"notes\" elements too big to embed.\n",
+    "too_long_pruned_notes_counts = [\n",
     "    count for notes_element in pruned_notes\n",
     "    if (count := usc.count_tokens_xml_clean(notes_element)) > embed.CONTEXT_LENGTH\n",
-    "), reverse=True)"
+    "]\n",
+    "\n",
+    "with output_box():\n",
+    "    display(sorted(too_long_pruned_notes_counts, reverse=True))"
    ]
   },
   {


### PR DESCRIPTION
**This is a request to merge commits into the [`usc`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/usc) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

This adds comments, splits up the code slightly more for readability, and uses a height-limited output box. (The output box is why this makes the notebook shorter: the values displayed in it are not saved in the notebook.)

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/usc-next) for unit test status.