### PR TITLE
Handle loose USC archives (as well as nested)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -75,6 +75,7 @@
         "subaudit",
         "subelement",
         "subelements",
+        "subsubdir",
         "tablefmt",
         "tamasfe",
         "tiktoken",


### PR DESCRIPTION
**This is a request to merge commits into the [`usc`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/usc) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

The official USC archive contains "loose" top-level files rather than a top-level directory. As the FIXME this takes care of noted, we didn't support that (expecting a top-level directory). Both work now.

I've tested this with the repacked (higher compression) archive we've been using that has a top-level directory ("nested"), as well as with the official archive that does not ("loose").

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/usc-extract) for unit test status.