### PR TITLE
Report lost "text" and "tail" text in get_embeddable_elements

### DIFF
--- a/embed/demos/usc.py
+++ b/embed/demos/usc.py
@@ -207,8 +207,8 @@ def get_embeddable_elements(section):
             selection.append(element)
         elif len(element) == 0:  # We're at the bottom and it's still too big.
             _logger.error('Too-big leaf %r (%d tokens).', element, token_count)
-        else:
-            pass  # FIXME: Check for text this element directly contains.
+        elif element.text and (lost_text := element.text.strip()):
+            _logger.warning('%s: lost text: %r', element.tag, lost_text)
 
     return selection
 

--- a/notebooks/demos/usc_42.ipynb
+++ b/notebooks/demos/usc_42.ipynb
@@ -405,11 +405,11 @@
     {
      "data": {
       "text/plain": [
-       "{<Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fd516c01f40>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fd516e60c40>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fd516e60ec0>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fd516e61000>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fd516e62140>}"
+       "{<Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f950f97a9c0>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f950fbde540>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f950fbde600>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f950fbde700>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f951110ee80>}"
       ]
      },
      "execution_count": 24,
@@ -430,7 +430,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<subsection xmlns=\"http://xml.house.gov/schemas/uslm/1.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" style=\"-uslm-lc:I21\" class=\"indent0\" status=\"repealed\"><num value=\"d\">“[(d)</num><content> Repealed. <ref href=\"/us/pl/109/482/tI/s104/b/3/E\">Pub. L. 109–482, title I, § 104(b)(3)(E)</ref>, <date date=\"2007-01-15\">Jan. 15, 2007</date>, <ref href=\"/us/stat/120/3694\">120 Stat. 3694</ref>.]</content>\n",
+      "<subsection xmlns=\"http://xml.house.gov/schemas/uslm/1.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" style=\"-uslm-lc:I21\" class=\"indent0\" status=\"repealed\"><num value=\"c\">“[(c)</num><content> Repealed. <ref href=\"/us/pl/105/276/tV/s582/a/4\">Pub. L. 105–276, title V, § 582(a)(4)</ref>, <date date=\"1998-10-21\">Oct. 21, 1998</date>, <ref href=\"/us/stat/112/2643\">112 Stat. 2643</ref>.]</content>\n",
       "</subsection>\n",
       "\n"
      ]
@@ -489,7 +489,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6a6fff2355db4cc38b3cefb349a6621a",
+       "model_id": "8faf5c14155047c3b679162b64926f4c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -514,7 +514,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "26792a8d0cd142e8adad590a3165e227",
+       "model_id": "e1f961d3618841a2b648c43f2f9cb0e9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -545,7 +545,7 @@
     {
      "data": {
       "text/plain": [
-       "<Element {http://xml.house.gov/schemas/uslm/1.0}section at 0x7fd516bd1180>"
+       "<Element {http://xml.house.gov/schemas/uslm/1.0}section at 0x7f950f948d00>"
       ]
      },
      "execution_count": 31,
@@ -586,7 +586,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a87b722d8d6442c6aa56cbda30ae614a",
+       "model_id": "7b32311acca94800a78c26f93e9a425c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -611,8 +611,8 @@
     {
      "data": {
       "text/plain": [
-       "[<Element {http://xml.house.gov/schemas/uslm/1.0}meta at 0x7fd516c02780>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}main at 0x7fd516c032c0>]"
+       "[<Element {http://xml.house.gov/schemas/uslm/1.0}meta at 0x7f950fb45140>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}main at 0x7f950fb45180>]"
       ]
      },
      "execution_count": 34,
@@ -709,7 +709,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1e7cde5b81404117af9420cbdd8ccbef",
+       "model_id": "d131ebf5c0b4418d9abba72ca5a005c0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -761,7 +761,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d7ca9c3b51b548eeb02da2b72f60dcd0",
+       "model_id": "9ba968c072ad435f80a0b4db038e8228",
        "version_major": 2,
        "version_minor": 0
       },
@@ -890,7 +890,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d4d06b61271f427e8b3c4a2f1725ede2",
+       "model_id": "99177e55736e43a4a168c8ca0ee66245",
        "version_major": 2,
        "version_minor": 0
       },
@@ -954,7 +954,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "68c2514f05b142debd5e330148fcf369",
+       "model_id": "db902fcc3a9646f6aafe848d5ae5bbef",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1062,7 +1062,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total time elapsed: 17.889168s\n"
+      "Total time elapsed: 17.211052s\n"
      ]
     }
    ],
@@ -1191,7 +1191,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4f96ecd586de4821beb18f8dd71e26b5",
+       "model_id": "f6c2c99420544abe819960620ba10640",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1260,7 +1260,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "907562c7b4164b8c919dbb0dc540c0d5",
+       "model_id": "a7f50450446945838a20e15eb7b775de",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1450,7 +1450,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f2facfdc48ec48c3a99269ebcaad35a7",
+       "model_id": "ee736351938c490d949083d0500e8ad7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1498,7 +1498,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ed22d1d964074ebeac09828585f0e223",
+       "model_id": "ce1f0f95f087489698a29114708fe44f",
        "version_major": 2,
        "version_minor": 0
       },

--- a/notebooks/demos/usc_42.ipynb
+++ b/notebooks/demos/usc_42.ipynb
@@ -10,10 +10,8 @@
     "import contextlib\n",
     "import copy\n",
     "import itertools\n",
-    "import logging\n",
     "from pathlib import Path\n",
     "from pprint import pp\n",
-    "import time\n",
     "\n",
     "from IPython.display import display\n",
     "import clock_timer\n",
@@ -407,11 +405,11 @@
     {
      "data": {
       "text/plain": [
-       "{<Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fc204e2ca80>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fc205090d40>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fc205092800>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fc206452200>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fc20660f240>}"
+       "{<Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fd516c01f40>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fd516e60c40>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fd516e60ec0>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fd516e61000>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7fd516e62140>}"
       ]
      },
      "execution_count": 24,
@@ -432,7 +430,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<subsection xmlns=\"http://xml.house.gov/schemas/uslm/1.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" style=\"-uslm-lc:I21\" class=\"indent0\" status=\"repealed\"><num value=\"g\">“[(g)</num><content> Repealed. <ref href=\"/us/pl/101/508/tIV/s4118/i/2\">Pub. L. 101–508, title IV, § 4118(i)(2)</ref>, <date date=\"1990-11-05\">Nov. 5, 1990</date>, <ref href=\"/us/stat/104/1388-70\">104 Stat. 1388–70</ref>.]</content>\n",
+      "<subsection xmlns=\"http://xml.house.gov/schemas/uslm/1.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" style=\"-uslm-lc:I21\" class=\"indent0\" status=\"repealed\"><num value=\"d\">“[(d)</num><content> Repealed. <ref href=\"/us/pl/109/482/tI/s104/b/3/E\">Pub. L. 109–482, title I, § 104(b)(3)(E)</ref>, <date date=\"2007-01-15\">Jan. 15, 2007</date>, <ref href=\"/us/stat/120/3694\">120 Stat. 3694</ref>.]</content>\n",
       "</subsection>\n",
       "\n"
      ]
@@ -491,7 +489,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2918bc5caf0e4f739f4784af904b508e",
+       "model_id": "6a6fff2355db4cc38b3cefb349a6621a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -516,7 +514,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cced8a059599487dab315be89555e4f8",
+       "model_id": "26792a8d0cd142e8adad590a3165e227",
        "version_major": 2,
        "version_minor": 0
       },
@@ -547,7 +545,7 @@
     {
      "data": {
       "text/plain": [
-       "<Element {http://xml.house.gov/schemas/uslm/1.0}section at 0x7fc2050fd4c0>"
+       "<Element {http://xml.house.gov/schemas/uslm/1.0}section at 0x7fd516bd1180>"
       ]
      },
      "execution_count": 31,
@@ -588,7 +586,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d45455ea471f4d469035afa1b4d65db1",
+       "model_id": "a87b722d8d6442c6aa56cbda30ae614a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -613,8 +611,8 @@
     {
      "data": {
       "text/plain": [
-       "[<Element {http://xml.house.gov/schemas/uslm/1.0}meta at 0x7fc204f1d500>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}main at 0x7fc204f1c980>]"
+       "[<Element {http://xml.house.gov/schemas/uslm/1.0}meta at 0x7fd516c02780>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}main at 0x7fd516c032c0>]"
       ]
      },
      "execution_count": 34,
@@ -711,7 +709,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b31e6c48e7144361879e85acb8d379e3",
+       "model_id": "1e7cde5b81404117af9420cbdd8ccbef",
        "version_major": 2,
        "version_minor": 0
       },
@@ -763,7 +761,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "58e388e612474b6bbdbb5cc2a74f86f8",
+       "model_id": "d7ca9c3b51b548eeb02da2b72f60dcd0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -892,7 +890,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "636417fd3b1d48dd9bd3546a1f031e44",
+       "model_id": "d4d06b61271f427e8b3c4a2f1725ede2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -956,7 +954,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8981a6b6ceb947edb9d9ee2dd4a7376d",
+       "model_id": "68c2514f05b142debd5e330148fcf369",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1064,7 +1062,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total time elapsed: 17.960409s\n"
+      "Total time elapsed: 17.889168s\n"
      ]
     }
    ],
@@ -1193,7 +1191,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "81ba80ada9b840b3ac6824834926b0e5",
+       "model_id": "4f96ecd586de4821beb18f8dd71e26b5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1262,7 +1260,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5667324261a94c59a1edd142d9581804",
+       "model_id": "907562c7b4164b8c919dbb0dc540c0d5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1452,7 +1450,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ae173b65136d49afb2fdf01e689231e9",
+       "model_id": "f2facfdc48ec48c3a99269ebcaad35a7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1500,7 +1498,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a9f52c001c784fdaa07a4d828fc7e4a5",
+       "model_id": "ed22d1d964074ebeac09828585f0e223",
        "version_major": 2,
        "version_minor": 0
       },


### PR DESCRIPTION
**This is a request to merge commits into the [`usc`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/usc) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

It appears no "text" or "tail" text appears in any element `get_embeddable_elements` would split up, in Title 42.

We should probably provide a keyword argument to make it an error if it does happen, though, if we're not going to add logic to preserve such text in a situation where we would break up an element that has it. Such a "strict" mode should also apply to a too-big leaf, another condition we don't currently encounter but that would be skipped.

This PR does *not* itself add any such strict mode. For this reason, one of the related FIXMEs is retained.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/usc-lost) for unit test status.