### PR TITLE
Have get_embeddable_elements raise on lost content

### DIFF
--- a/notebooks/demos/usc_42.ipynb
+++ b/notebooks/demos/usc_42.ipynb
@@ -405,11 +405,11 @@
     {
      "data": {
       "text/plain": [
-       "{<Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f950f97a9c0>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f950fbde540>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f950fbde600>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f950fbde700>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f951110ee80>}"
+       "{<Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x2242cb14cc0>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x2244d8dde80>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x2245000ca00>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x2245000cc00>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x2245000cd00>}"
       ]
      },
      "execution_count": 24,
@@ -489,7 +489,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8faf5c14155047c3b679162b64926f4c",
+       "model_id": "92afa7b2d1014d5d96411ce6420a831a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -514,7 +514,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e1f961d3618841a2b648c43f2f9cb0e9",
+       "model_id": "475facc4238b4f4cbeac7e65c15aea3d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -545,7 +545,7 @@
     {
      "data": {
       "text/plain": [
-       "<Element {http://xml.house.gov/schemas/uslm/1.0}section at 0x7f950f948d00>"
+       "<Element {http://xml.house.gov/schemas/uslm/1.0}section at 0x2244d867c40>"
       ]
      },
      "execution_count": 31,
@@ -586,7 +586,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7b32311acca94800a78c26f93e9a425c",
+       "model_id": "39a18e1b07ff43958e9aa33d61f29977",
        "version_major": 2,
        "version_minor": 0
       },
@@ -611,8 +611,8 @@
     {
      "data": {
       "text/plain": [
-       "[<Element {http://xml.house.gov/schemas/uslm/1.0}meta at 0x7f950fb45140>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}main at 0x7f950fb45180>]"
+       "[<Element {http://xml.house.gov/schemas/uslm/1.0}meta at 0x2245000d500>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}main at 0x2245000cc40>]"
       ]
      },
      "execution_count": 34,
@@ -709,7 +709,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d131ebf5c0b4418d9abba72ca5a005c0",
+       "model_id": "662aa20b2de2416fa5b85c1ac8233a68",
        "version_major": 2,
        "version_minor": 0
       },
@@ -761,7 +761,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9ba968c072ad435f80a0b4db038e8228",
+       "model_id": "6590a26417474277af3aab2d0dc78890",
        "version_major": 2,
        "version_minor": 0
       },
@@ -890,7 +890,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "99177e55736e43a4a168c8ca0ee66245",
+       "model_id": "9d28a007ea2c46dc84f2f08ec0942038",
        "version_major": 2,
        "version_minor": 0
       },
@@ -954,7 +954,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "db902fcc3a9646f6aafe848d5ae5bbef",
+       "model_id": "9e8176998fef4817ab974dbe090b046c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1062,7 +1062,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total time elapsed: 17.211052s\n"
+      "Total time elapsed: 21.302429s\n"
      ]
     }
    ],
@@ -1191,7 +1191,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f6c2c99420544abe819960620ba10640",
+       "model_id": "5bbd9842de414d638c72fa3a60ac41fc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1260,7 +1260,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a7f50450446945838a20e15eb7b775de",
+       "model_id": "dc2aeb08af56486db371218ac5f8b104",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1450,7 +1450,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ee736351938c490d949083d0500e8ad7",
+       "model_id": "3d9fcd7af10a42e5a823fcebf9209a4f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1498,7 +1498,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ce1f0f95f087489698a29114708fe44f",
+       "model_id": "3f8eb8ca8c8a41e992599d9711894b98",
        "version_major": 2,
        "version_minor": 0
       },


### PR DESCRIPTION
**This is a request to merge commits into the [`usc`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/usc) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

This modifies `get_embeddable_elements` to add a strict mode, which is enabled by default and which, after computing the entire breakdown, checks if *any* of the three situations in which content would be lost has occurred. If so, it raises `ValueError`, reporting how many times each of the three general situations occurred. (The idea behind it being `ValueError` is that all these situations occur, or not, based on the value of the input, not its type, or the result of attempting to look something up, etc.)

This also upgrades the lost "text" text and lost "tail" text situations from warning to error in the logging done immediately when the problems are discovered, so all three have "error" severity.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/usc-strict) for unit test status.