### PR TITLE
Eliminate _require_usc_archive helper

### DIFF
--- a/embed/demos/usc.py
+++ b/embed/demos/usc.py
@@ -58,23 +58,6 @@ def _download_usc(data_dir, archive_filename):
     )
 
 
-def _require_usc_archive(data_dir, download):
-    """
-    If the archive is absent, either fail or download it, as appropriate.
-
-    Raises various exceptions on failure. Returns the archive path on success.
-    """
-    archive_filename = f'{USC_STEM}.zip'
-    archive_path = Path(data_dir, archive_filename)
-
-    if not archive_path.is_file():
-        if not download:
-            raise FileNotFoundError(f'no archive: {archive_path}')
-        _download_usc(data_dir, archive_filename)
-
-    return archive_path
-
-
 def _do_extract_usc(subdir, archive_path):
     """
     Create a target directory, extract the USC, and eliminate extra nesting.
@@ -110,8 +93,15 @@ def extract_usc(data_dir, *, download=False):
     if subdir.is_dir():
         return
 
-    # Ensure the archive exists, or raise an exception.
-    archive_path = _require_usc_archive(data_dir, download)
+    # Determine the filename and full path for the archive file.
+    archive_filename = f'{USC_STEM}.zip'
+    archive_path = Path(data_dir, archive_filename)
+
+    # If the archive is absent, either fail or download it, as appropriate.
+    if not archive_path.is_file():
+        if not download:
+            raise FileNotFoundError(f'no archive: {archive_path}')
+        _download_usc(data_dir, archive_filename)
 
     # Actually extract the archive.
     _do_extract_usc(subdir, archive_path)


### PR DESCRIPTION
**This is a request to merge commits into the [`usc`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/usc) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

This keeps much of the previous refactoring, but it puts the code of `_require_usc_archive` back in `extract_usc`. That helper function didn't really do a single clear job or self-contained group of jobs, and I think it made the code harder rather than easier to understand.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/usc-extract) for unit test status.