### PR TITLE
Drop TODO about defusedxml

### DIFF
--- a/notebooks/demos/usc.ipynb
+++ b/notebooks/demos/usc.ipynb
@@ -50,8 +50,6 @@
     }
    ],
    "source": [
-    "# TODO: Consider using defusedxml.\n",
-    "\n",
     "usc1tree = ET.parse(usc1)\n",
     "usc1tree"
    ]


### PR DESCRIPTION
**This is a request to merge commits into the [`usc`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/usc) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

It was from before we were using `lxml`.

[My branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/usc-todo) has unit test status, though this change should not be able to affect that.