### PR TITLE
Extract schema-prefix building to usc module

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,6 +52,7 @@
         "nbdime",
         "ndarray",
         "nonblocking",
+        "nsmap",
         "numpy",
         "openai",
         "orjson",

--- a/embed/demos/usc.py
+++ b/embed/demos/usc.py
@@ -14,6 +14,7 @@ __all__ = [
     'full_tabulate_token_counts',
     'show_tails',
     'show_wrapped',
+    'get_schema_prefix',
     'get_embeddable_elements',
     'is_repealed',
 ]
@@ -266,6 +267,11 @@ def show_wrapped(element, *, width=140, limit=None):
     element_text = ET.tostring(element, encoding='unicode')
     display_text = element_text if limit is None else element_text[:limit]
     print('\n'.join(textwrap.wrap(display_text, width=width)))
+
+
+def get_schema_prefix(root):
+    """Get the brace-enclosed XML schema prefix that qualifies tag names."""
+    return '{%s}' % root.nsmap[None]
 
 
 # FIXME: Avoid breaking up elements like <em> that are not, in a conceptual

--- a/notebooks/demos/usc_42.ipynb
+++ b/notebooks/demos/usc_42.ipynb
@@ -261,7 +261,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "schema_prefix = f'{{{usc42root.nsmap[None]}}}'\n",
+    "schema_prefix = usc.get_schema_prefix(usc42root)\n",
     "section_tag = schema_prefix + 'section'\n",
     "sections = usc42tree.findall(f'.//{section_tag}')"
    ]
@@ -405,11 +405,11 @@
     {
      "data": {
       "text/plain": [
-       "{<Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x14b9ed44b00>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x14b9ed45040>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x14b9ed45080>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x14b9ed4f8c0>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x14b9edf63c0>}"
+       "{<Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x23c7d748080>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x23c7d74ed40>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x23c7d74f5c0>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x23c7d74ffc0>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x23c7d806680>}"
       ]
      },
      "execution_count": 24,
@@ -430,7 +430,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<subsection xmlns=\"http://xml.house.gov/schemas/uslm/1.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" style=\"-uslm-lc:I21\" class=\"indent0\" status=\"repealed\"><num value=\"c\">“[(c)</num><content> Repealed. <ref href=\"/us/pl/105/276/tV/s582/a/4\">Pub. L. 105–276, title V, § 582(a)(4)</ref>, <date date=\"1998-10-21\">Oct. 21, 1998</date>, <ref href=\"/us/stat/112/2643\">112 Stat. 2643</ref>.]</content>\n",
+      "<subsection xmlns=\"http://xml.house.gov/schemas/uslm/1.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" style=\"-uslm-lc:I21\" class=\"indent0\" status=\"repealed\"><num value=\"d\">“[(d)</num><content> Repealed. <ref href=\"/us/pl/109/482/tI/s104/b/3/E\">Pub. L. 109–482, title I, § 104(b)(3)(E)</ref>, <date date=\"2007-01-15\">Jan. 15, 2007</date>, <ref href=\"/us/stat/120/3694\">120 Stat. 3694</ref>.]</content>\n",
       "</subsection>\n",
       "\n"
      ]
@@ -490,7 +490,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4b6e1b24dacb4bbf8554a21f2394587e",
+       "model_id": "771f798b826242cab1a44191756ceb68",
        "version_major": 2,
        "version_minor": 0
       },
@@ -515,7 +515,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e88895aa03094a83bcfd463db5bba588",
+       "model_id": "3e82347feef5487383d0f2556fe10b0e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -546,7 +546,7 @@
     {
      "data": {
       "text/plain": [
-       "<Element {http://xml.house.gov/schemas/uslm/1.0}section at 0x14b9edb7d40>"
+       "<Element {http://xml.house.gov/schemas/uslm/1.0}section at 0x23c7d7b6ec0>"
       ]
      },
      "execution_count": 31,
@@ -587,7 +587,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8c06657fa6a1463fae9dfdc0b93adaad",
+       "model_id": "195ecb2d049c48d28f88f541a5a377f0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -612,8 +612,8 @@
     {
      "data": {
       "text/plain": [
-       "[<Element {http://xml.house.gov/schemas/uslm/1.0}meta at 0x14bd561ab00>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}main at 0x14bd561b0c0>]"
+       "[<Element {http://xml.house.gov/schemas/uslm/1.0}meta at 0x23c7d61b2c0>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}main at 0x23c7d1d6300>]"
       ]
      },
      "execution_count": 34,
@@ -710,7 +710,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b2d8555589674b42ae352fabf68056db",
+       "model_id": "bc68ad84c47343ee9aee821bbb8f7c86",
        "version_major": 2,
        "version_minor": 0
       },
@@ -762,7 +762,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ab1d25a59a2c4c479c5bf3811b9d2797",
+       "model_id": "6063617ab01b445bb9d0af10ec205c1b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -891,7 +891,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2726e50905f2447faf3cea184b61cc07",
+       "model_id": "7631878025e5455db788f8bcc8a41d60",
        "version_major": 2,
        "version_minor": 0
       },
@@ -955,7 +955,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ad04a2d452024d07badcd409c37a0a2c",
+       "model_id": "5cadb5ddc64d4045968e0350e13dee99",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1063,7 +1063,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total time elapsed: 20.009302s\n"
+      "Total time elapsed: 19.521868s\n"
      ]
     }
    ],
@@ -1192,7 +1192,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b624ca8fcb9343eb93bea270edb3e3eb",
+       "model_id": "e7b12ee8948f400cbe825accfefba51a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1261,7 +1261,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fe03561851fc48a9920ae2162abc9f29",
+       "model_id": "ab648283b7694a92aeadfc2e12bc9e80",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1451,7 +1451,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b03063ddcfb34cddaba0d8879a289cc8",
+       "model_id": "0c9a74a39ddf4c4c88c4b41c24587eda",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1499,7 +1499,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d5f2d7789f874e989f55d6d4b5cdc5bf",
+       "model_id": "adcc97d147a94245aeab5e87c8669d9d",
        "version_major": 2,
        "version_minor": 0
       },


### PR DESCRIPTION
**This is a request to merge commits into the [`usc`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/usc) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

The new `get_schema_prefix` function provides the behavior of the old code, but it is also refactored to format the string in a way that the code itself is easier to read and verify correct.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/usc-schema) for unit test status.