### PR TITLE
Explicitly don't track .venv and such directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@ __pycache__/
 .ipynb_checkpoints/
 .jupyter_ystore.db
 
-# Local tox files
+# Local environments
 .tox/
+.venv*/
+venv*/
 
 # OpenAI API key
 .api_key


### PR DESCRIPTION
Same reasoning as 7b50cf6 (#167). Even though a virtual environment should and nearly always does contain a `.gitignore` file causing its contents (and thus it) to be ignored by Git, it sometimes makes sense to recursively delete such a directory, and while that is being done, its `.gitignore` file will often end up being deleted early on, causing editors and other tools that display Git status to scurry to show all the numerous (yet conceptually irrelevant) changes. In rare cases, something might even be staged by accident as a result, though that's not the main motivation for this change (nor for #167).

In this project, virtual environment directories inside the workspace are not used as often as a `.tox/` directory inside the workspace, since Poetry defaults to storing the environments it manages elsewhere. However, there are some important uses of workspace-local venvs; see #165.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/venv) for unit test status.