### PR TITLE
Bring back notes_tag variable in usc_42.ipynb

### DIFF
--- a/notebooks/demos/usc_42.ipynb
+++ b/notebooks/demos/usc_42.ipynb
@@ -1285,6 +1285,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "notes_tag = schema_prefix + 'notes'"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 66,
    "metadata": {},
    "outputs": [

--- a/notebooks/demos/usc_42.ipynb
+++ b/notebooks/demos/usc_42.ipynb
@@ -405,11 +405,11 @@
     {
      "data": {
       "text/plain": [
-       "{<Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x18f01a4f300>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x18f01a4fc00>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x18f01a4fe40>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x18f01aef4c0>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x18f01b06140>}"
+       "{<Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f708ff8b400>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f708ff8bb00>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f7090023740>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f710c176380>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}subsection at 0x7f710e24a100>}"
       ]
      },
      "execution_count": 24,
@@ -490,7 +490,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8e91fe9c7c084dc49069ef21d14c4170",
+       "model_id": "a2cce78f8c514306896ea331308cf62a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -515,7 +515,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a351c87a958a45d2acc50db5e06dc96a",
+       "model_id": "353fd49ecd5849559db089619c0b7e54",
        "version_major": 2,
        "version_minor": 0
       },
@@ -546,7 +546,7 @@
     {
      "data": {
       "text/plain": [
-       "<Element {http://xml.house.gov/schemas/uslm/1.0}section at 0x18f01ab6fc0>"
+       "<Element {http://xml.house.gov/schemas/uslm/1.0}section at 0x7f708fff2e00>"
       ]
      },
      "execution_count": 31,
@@ -587,7 +587,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1ab1e0f53b7d4671aae23653a3f67e9b",
+       "model_id": "6313eb6054b64028a7aaabb29f13d5c1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -612,8 +612,8 @@
     {
      "data": {
       "text/plain": [
-       "[<Element {http://xml.house.gov/schemas/uslm/1.0}meta at 0x18f0a90be80>,\n",
-       " <Element {http://xml.house.gov/schemas/uslm/1.0}main at 0x18f0a935680>]"
+       "[<Element {http://xml.house.gov/schemas/uslm/1.0}meta at 0x7f709013c600>,\n",
+       " <Element {http://xml.house.gov/schemas/uslm/1.0}main at 0x7f709013c3c0>]"
       ]
      },
      "execution_count": 34,
@@ -710,7 +710,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "569bff7cb09d43728f9ad9a5dccfdf54",
+       "model_id": "7a04e077ea0f4b968926d1e1f8fb8ae1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -762,7 +762,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0f9c5c6e1edb4eeb81e998a44085a0e6",
+       "model_id": "f7954d9de89f458c854ebfa0daef1ede",
        "version_major": 2,
        "version_minor": 0
       },
@@ -891,7 +891,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9aa1320b6b1c45fb902d44c4b0be28c1",
+       "model_id": "7bb971599ae045679ccf19f57890b968",
        "version_major": 2,
        "version_minor": 0
       },
@@ -947,7 +947,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "70ee675801ba47f5b6ee618e138c16ae",
+       "model_id": "56da462b3643429cbaccb9dcae181d16",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1055,7 +1055,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total time elapsed: 19.516774s\n"
+      "Total time elapsed: 17.288494s\n"
      ]
     }
    ],
@@ -1184,7 +1184,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cd1e16036aa549ba88762a80608d8eae",
+       "model_id": "a6cfa6cb67d642ee821cb30dae665bb2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1253,7 +1253,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "acaf70456df245aea145e13d3f6fa135",
+       "model_id": "8a78b631ba1b493cbfad3f7b129aa1ce",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1443,7 +1443,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8b2cb3bff21d48f9904e6604513ed3e2",
+       "model_id": "cf4694ac6e8f43a2b2dc2030e8ab8296",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1491,7 +1491,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a1223dfb64414d878ce6fedfad93b160",
+       "model_id": "a461acab026a4d25b8a6d4a472f2bbd0",
        "version_major": 2,
        "version_minor": 0
       },


### PR DESCRIPTION
**This is a request to merge commits into the [`usc`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/usc) feature branch, *not* into [`main`](https://github.com/dmvassallo/EmbeddingScratchwork/tree/main).**

I had prematurely removed it, in #198. This puts it back and reruns the notebook, as two separate commits so the first can be a pure revert for easier inspection. The rest of #198 is fine; it's just the removal of `notes_tag` when it was still used once near the end of the notebook that was the problem.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/usc-notes) for unit test status, though they should be completely unaffected.