### PR TITLE
Update CORS url_end_pattern for port forwarding

### DIFF
--- a/.devcontainer/postStart
+++ b/.devcontainer/postStart
@@ -28,7 +28,7 @@ readonly config_path=~/.jupyter/jupyter_lab_config.py
 readonly auto_comment='# postStart generated'
 
 # Python regex for the end of a permitted URL, when the beginning is also okay.
-readonly url_end_pattern='-[89][0-9]{3}\.preview\.app\.github\.dev'
+readonly url_end_pattern='-[89][0-9]{3}\.(?:preview\.)?app\.github\.dev'
 
 in_codespace() {
     # TODO: Find a more reliable way to check if we are running in a codespace.


### PR DESCRIPTION
https://github.blog/changelog/2023-07-14-codespaces-port-forwarding-domain-name-updates/

This is the same change as in https://github.com/EliahKagan/palgoviz/pull/161. It's a stopgap until refactoring allows `GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN` with no decrease in code clarity.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/cors) for unit test status, though this should definitely not be able to affect that.