### PR TITLE
Set minimum requests version in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - numpy
   - openai
   - orjson
-  - requests
+  - requests>=2.31.0
   - safetensors
 
   # For testing


### PR DESCRIPTION
We're not pinning dependencies in `environment.yml`, and most of them do not give version constraints. For requests, I think it makes sense to constrain the version to be at least 2.30.0, so that a version affected by CVE-2023-32681 is never used accidentally. See #123.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/deps) for unit test status, though that is extremely unlikely to be affected, since the way conda dependencies are obtained on CI always gets a later version than that even without the version constraint.