### PR TITLE
Have conda/mamba install blake3 from conda-forge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
   - python=3.11
   - backoff
+  - blake3
   - dulwich
   - numpy
   - openai
@@ -37,7 +38,6 @@ dependencies:
   # PyPI
   - pip
   - pip:
-    - blake3
     - pylint-actions
     - pylint-exit
     - subaudit


### PR DESCRIPTION
Instead of using pip.

This does not affect poetry/pip version management. It only affects how dependencies are obtained when installation is done in a conda environment for development purposes using commands like "conda env create", "mamba env create", "conda env update", etc.

blake3 from the conda-forge channel was until recentky at the old version 0.2.1, but now it is up to the current version 0.3.3. See https://github.com/conda-forge/blake3-feedstock/pull/14 and https://github.com/conda-forge/blake3-feedstock/pull/16.

See [my branch](https://github.com/EliahKagan/EmbeddingScratchwork/commits/blake3-conda-dependency/) for unit test status.