### PR TITLE
Have Dependabot group Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,10 @@ updates:
       interval: monthly
     allow:
       - dependency-type: all
-    open-pull-requests-limit: 100
+    open-pull-requests-limit: 20
+    groups:
+      python-dependencies:
+        patterns: ['*']
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
Now that grouped version updates are considered stable:

https://github.blog/changelog/2023-08-24-grouped-version-updates-for-dependabot-are-generally-available/