### PR TITLE
Regard HTTP 403 links as "alive", for now

### DIFF
--- a/.github/workflows/markdown-links-config.json
+++ b/.github/workflows/markdown-links-config.json
@@ -1,0 +1,3 @@
+{
+    "aliveStatusCodes": [200, 403]
+}

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Check Markdown links
         uses: gaurav-nelson/github-action-markdown-link-check@1.0.15
+        with:
+          config-file: .github/workflows/markdown-links-config.json
 
   markdownlint-cli2:
     name: Lint


### PR DESCRIPTION
This reconfigures `markdown-link-check` to treat both HTTP 200 and HTTP 403 status codes as meaning the link is not broken. This has a high risk of false detection. It is a temporary workaround for the problem of pages on the OpenAI website (linked to from the readme) returning HTTP 403 when accessed from GitHub Actions runners.