### PR TITLE
Fix broken link about installing mamba

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ conda activate EmbeddingScratchwork
 pip install -e .
 ```
 
-[`mamba`](https://mamba.readthedocs.io/en/latest/installation.html) may be used
-in place of `conda` if it is installed.
+[`mamba`](https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html)
+may be used in place of `conda` if it is installed.
 
 #### Your OpenAI API key
 


### PR DESCRIPTION
The URL for the mamba installation page changed, and the old URL does not work as a redirect. This updates it.

This change is analogous to https://github.com/EliahKagan/palgoviz/pull/190.

Together with #266, this should make the "Check Markdown" workflow all-green again.