### PR TITLE
Don't have Dependabot group openai updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     groups:
       python-dependencies:
         patterns: ['*']
+        exclude-patterns: ['openai']
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
So Dependabot commands can be issued specific to updates to that package. Currently we are holding it back <1. See #268 (531bdd8).