### PR TITLE
Reconfigure Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,18 @@ updates:
       interval: monthly
     allow:
       - dependency-type: all
-    open-pull-requests-limit: 20
+    ignore:
+      # Keep `openai` below 1.0.0.
+      - dependency-name: openai
+        update-types: ['version-update:semver-major']
     groups:
-      python-dependencies:
+      python:
         patterns: ['*']
-        exclude-patterns: ['openai']
 
-  - package-ecosystem: github-actions
+  - package-ecosystem: actions
     directory: '/'
     schedule:
       interval: daily
+    groups:
+      actions:
+        patterns: ['*']


### PR DESCRIPTION
Changes:

- Don't update the `openai` package at all, unless there were a new version in the <1.0.0 line that we are using. This project covers a few ways to retrieve embeddings from OpenAI, but it doesn't cover the new Python library (which has a different interface).
- No longer exclude `openai` from Python dependencies group, since now the only updates Dependabot should propose for it are those that we can take and that make sense to include with any others. (Most likely, there will never be a newer version <1.0.0.)
- Use as shorter name for the Python dependencies group, mostly to make pull request titles and commit messages easier to read.
- Remove the pull request limit for the Python dependencies, since far fewer PRs than that are opened at a time due to grouping.
- Use grouped version updates for GitHub Actions dependencies as well. Since the check is daily, this will usually not make a big difference. But grouping them automatically accommodates the occasional scenario where two or more related actions are updated in a way where it is incorrect or confusing to attempt to switch to the new versions one at a time. It also keeps the number of PRs down (if we were to let actions update PRs accumulate).

Unit test status can be seen [in my fork](https://github.com/EliahKagan/EmbeddingScratchwork/commit/3739044d6e9d7d4e38b1fd8f7d6f72cc3382fbe4), though it is not relevant to these changes. (This doesn't apply any updates, it just reconfigures Dependabot.)