### PR TITLE
Fix GHA package ecosystem name in `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       python:
         patterns: ['*']
 
-  - package-ecosystem: actions
+  - package-ecosystem: github-actions
     directory: '/'
     schedule:
       interval: daily


### PR DESCRIPTION
I broke this by accident in #316, rendering Dependabot inoperable. This fixes that, while keeping the intended changes from that PR.

(The automatic scan for syntactic correctness in `dependabot.yml` identified the problem, but the scan occurred too late: for some reason, it usually only happens after merging, and not in PRs.)

---

[Here's the commit](https://github.com/EliahKagan/EmbeddingScratchwork/commit/0e48a199747e260c48073b65875c36d21bf56c0d) in my fork, though as noted, the CI that would be relevant to changes in `dependabot.yml` occurs neither here nor there.